### PR TITLE
Add some string builtins

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,35 @@ FIXME
 
 ## Supported built-in functions
 
+### Arrays
+
 - [x] `array.concat` 
 - [x] `array.reverse`
 - [x] `array.slice`
+
+### Strings
+
+- [] `concat`
+- [x] `contains`
+- [x] `endswith`
+- [x] `format_int`
+- [x] `indexof`
+- [x] `indexof_n`
+- [x] `lower`
+- [x] `replace`
+- [x] `strings.reverse`
+- [] `strings.replace_n`
+- [x] `split`
+- [] `sprintf`
+- [x] `startswith`
+- [x] `substring`
+- [] `trim`
+- [] `trim_left`
+- [x] `trim_prefix`
+- [] `trim_right`
+- [x] `trim_suffix`
+- [x] `trim_space`
+- [x] `upper`
 
 ## Development
 

--- a/src/main/clojure/jarl/builtins/registry.clj
+++ b/src/main/clojure/jarl/builtins/registry.clj
@@ -1,11 +1,27 @@
 (ns jarl.builtins.registry
-  (:require [jarl.builtins.array :as array]))
+  (:require [jarl.builtins.array :as array]
+            [jarl.builtins.strings :as strings]))
 
-(def builtins {
-               "array.concat" array/builtin-concat
-               "array.reverse" array/builtin-reverse
-               "array.slice" array/builtin-slice
-               })
+(def builtins
+  {"array.concat" array/builtin-concat
+   "array.reverse" array/builtin-reverse
+   "array.slice" array/builtin-slice
+
+   "contains" strings/builtin-contains
+   "endswith" strings/builtin-endswith
+   "format_int" strings/builtin-format-int
+   "indexof" strings/builtin-indexof
+   "indexof_n" strings/builtin-indexof-n
+   "lower" strings/builtin-lower
+   "replace" strings/builtin-replace
+   "strings.reverse" strings/builtin-strings-reverse
+   "split" strings/builtin-split
+   "startswith" strings/builtin-startswith
+   "substring" strings/builtin-substring
+   "trim_prefix" strings/builtin-trim-prefix
+   "trim_suffix" strings/builtin-trim-suffix
+   "trim_space" strings/builtin-trim-space
+   "upper" strings/builtin-upper})
 
 (defn get-builtin [name]
   (get builtins name))

--- a/src/main/clojure/jarl/builtins/strings.clj
+++ b/src/main/clojure/jarl/builtins/strings.clj
@@ -1,0 +1,132 @@
+(ns jarl.builtins.strings
+  (:require [jarl.builtins.utils :refer [check-args]]
+            [clojure.string :as str])
+  (:import (se.fylling.jarl BuiltinException)
+           (java.util.regex Pattern)))
+
+(defn builtin-contains
+  "Implementation of contains built-in"
+  {:builtin "contains" :args-types ["string" "string"]}
+  [^String s ^String search]
+  (check-args (meta #'builtin-contains) s search)
+  (.contains s search))
+
+(defn builtin-endswith
+  "Implementation of endswith built-in"
+  {:builtin "endswith" :args-types ["string" "string"]}
+  [s search]
+  (check-args (meta #'builtin-endswith) s search)
+  (str/ends-with? s search))
+
+(defn builtin-format-int
+  "Implementation of format_int built-in"
+  {:builtin "format_int" :args-types ["number" "number"]}
+  [number base]
+  (check-args (meta #'builtin-format-int) number base)
+  (Integer/toString number base))
+
+(defn builtin-indexof
+  "Implementation of indexof built-in"
+  {:builtin "indexof" :args-types ["string" "string"]}
+  [s search]
+  (check-args (meta #'builtin-indexof) s search)
+  (let [result (str/index-of s search)]
+    (if (nil? result)
+      -1
+      result)))
+
+(defn builtin-indexof-n
+  "Implementation of indexof_n built-in"
+  {:builtin "indexof_n" :args-types ["string" "string"]}
+  [s search]
+  (check-args (meta #'builtin-indexof-n) s search)
+  (loop [index (str/index-of s search)
+         indices []]
+    (if (nil? index)
+      indices
+      (recur (str/index-of s search (inc index)) (conj indices index)))))
+
+(defn builtin-lower
+  "Implementation of lower built-in"
+  {:builtin "lower" :args-types ["string"]}
+  [^String s]
+  (check-args (meta #'builtin-lower) s)
+  (.toLowerCase s))
+
+(defn builtin-replace
+  "Implementation of replace built-in"
+  {:builtin "replace" :args-types ["string" "string" "string"]}
+  [s old new]
+  (check-args (meta #'builtin-replace) s old new)
+  (str/replace s old new))
+
+(defn builtin-strings-reverse
+  "Implementation of strings.reverse built-in"
+  {:builtin "strings.reverse" :args-types ["string"]}
+  [s]
+  (check-args (meta #'builtin-strings-reverse) s)
+  (str/reverse s))
+
+(defn builtin-split
+  "Implementation of split built-in"
+  {:builtin "split" :args-types ["string" "string"]}
+  [s delim]
+  (check-args (meta #'builtin-split) s)
+  (if (= s delim)
+    ; Rego quirk? Not sure why this is so, or if there are more cases like this,
+    ; but we'll try to mimic this here as well
+    ["" ""]
+    (str/split s (re-pattern (Pattern/quote delim)))))
+
+(defn builtin-startswith
+  "Implementation of startswith built-in"
+  {:builtin "startswith" :args-types ["string" "string"]}
+  [s search]
+  (check-args (meta #'builtin-startswith) s search)
+  (str/starts-with? s search))
+
+; Note: Rego `substring` uses length as the second argument, while
+; Clojure `subs` uses the position in the string
+(defn builtin-substring
+  "Implementation of substring built-in"
+  {:builtin "substring" :args-types ["string" "number" "number"]}
+  [s start len]
+  (check-args (meta #'builtin-substring) s start len)
+  (if (neg-int? start)
+    (throw (BuiltinException. "eval_builtin_error: substring: negative offset"))
+    (let [end (+ start len)]
+      (if (or (> end (count s)) (neg-int? len))
+        (subs s start (count s))
+        (subs s start end)))))
+
+(defn builtin-trim-prefix
+  "Implementation of trim_prefix built-in"
+  {:builtin "trim_prefix" :args-types ["string" "string"]}
+  [s prefix]
+  (check-args (meta #'builtin-trim-prefix) s prefix)
+  (if (str/starts-with? s prefix)
+    (subs s (count prefix))
+    s))
+
+(defn builtin-trim-suffix
+  "Implementation of trim_suffix built-in"
+  {:builtin "trim_suffix" :args-types ["string" "string"]}
+  [s suffix]
+  (check-args (meta #'builtin-trim-suffix) s suffix)
+  (if (str/ends-with? s suffix)
+    (subs s 0 (- (count s) (count suffix)))
+    s))
+
+(defn builtin-trim-space
+  "Implementation of trim_space built-in"
+  {:builtin "trim_space" :args-types ["string"]}
+  [s]
+  (check-args (meta #'builtin-trim-space) s)
+  (str/trim s))
+
+(defn builtin-upper
+  "Implementation of upper built-in"
+  {:builtin "upper" :args-types ["string"]}
+  [^String s]
+  (check-args (meta #'builtin-upper) s)
+  (.toUpperCase s))

--- a/src/main/clojure/jarl/builtins/utils.clj
+++ b/src/main/clojure/jarl/builtins/utils.clj
@@ -1,6 +1,6 @@
 (ns jarl.builtins.utils
   (:import (se.fylling.jarl BuiltinException)
-           (clojure.lang PersistentVector)))
+           (clojure.lang PersistentVector PersistentHashSet)))
 
 (defn java->rego
   "Translates provided Java type to equivalent Rego type name"
@@ -14,6 +14,7 @@
     Long "number"
     Number "number"
     PersistentVector "array"
+    PersistentHashSet "set"
     (str "unknown type: " (type value) " from value: " value)))
 
 (defn check-args

--- a/src/test/clojure/jarl/builtins/array_test.clj
+++ b/src/test/clojure/jarl/builtins/array_test.clj
@@ -5,9 +5,9 @@
 
 (deftest builtin-concat-test
   (testing "concat arrays"
-    (is (= [1 2 3] (builtin-concat [1 2] [3])))
-    (is (= [1 2 3] (builtin-concat [1 2 3] [])))
-    (is (= [1 "a"] (builtin-concat [1] ["a"])))))
+    (is (= (builtin-concat [1 2] [3]) [1 2 3]))
+    (is (= (builtin-concat [1 2 3] []) [1 2 3]))
+    (is (= (builtin-concat [1] ["a"]) [1 "a"]))))
 
 (deftest builtin-concat-test-exceptions
   (testing "concat non-arrays"
@@ -16,9 +16,9 @@
 
 (deftest builtin-reverse-test
   (testing "reverse arrays"
-    (is (= [3 2 1] (builtin-reverse [1 2 3])))
-    (is (= ["a" "b" "c"] (builtin-reverse ["c" "b" "a"])))
-    (is (= [] (builtin-reverse [])))))
+    (is (= (builtin-reverse [1 2 3]) [3 2 1]))
+    (is (= (builtin-reverse ["c" "b" "a"]) ["a" "b" "c"]))
+    (is (= (builtin-reverse []) []))))
 
 (deftest builtin-reverse-test-exceptions
   (testing "reverse non-arrays"

--- a/src/test/clojure/jarl/builtins/strings_test.clj
+++ b/src/test/clojure/jarl/builtins/strings_test.clj
@@ -1,0 +1,106 @@
+(ns jarl.builtins.strings_test
+  (:require [clojure.test :refer [deftest is testing]]
+            [jarl.builtins.strings :refer [builtin-contains builtin-endswith builtin-format-int builtin-indexof
+                                           builtin-indexof-n builtin-lower builtin-replace builtin-strings-reverse
+                                           builtin-split builtin-startswith builtin-substring builtin-trim-prefix
+                                           builtin-trim-suffix builtin-trim-space builtin-upper]])
+  (:import (se.fylling.jarl BuiltinException)))
+
+(deftest builtin-contains-test
+  (testing "contains"
+    (is (= (builtin-contains "some text included" "text") true))
+    (is (= (builtin-contains "some ünicÖde works" "ünicÖde") true))
+    (is (= (builtin-contains "negative test" "positive") false))))
+
+(deftest builtin-endswith-test
+  (testing "endswith"
+    (is (= (builtin-endswith "some text included" "included") true))
+    (is (= (builtin-endswith "some ünicÖde" "ünicÖde") true))
+    (is (= (builtin-endswith "negative test" "positive") false))))
+
+(deftest builtin-format-int-test
+  (testing "format_int"
+    (is (= (builtin-format-int 10 10) "10"))
+    (is (= (builtin-format-int 10 2) "1010"))
+    (is (= (builtin-format-int 10 16) "a"))))
+
+(deftest builtin-indexof-test
+  (testing "indexof"
+    (is (= (builtin-indexof "some text included" "text") 5))
+    (is (= (builtin-indexof "some ünicÖde" "ünicÖde") 5))
+    (is (= (builtin-indexof "negative test" "positive") -1))))
+
+(deftest builtin-indexof-n-test
+  (testing "indexof_n"
+    (is (= (builtin-indexof-n "some text included" "e") [3 6 16]))
+    (is (= (builtin-indexof-n "some ünicÖde" "Ö") [9]))
+    (is (= (builtin-indexof-n "negative test" "positive") []))))
+
+(deftest builtin-lower-test
+  (testing "lower"
+    (is (= (builtin-lower "ABBA") "abba"))
+    (is (= (builtin-lower "ÛnicÖde") "ûnicöde"))))
+
+(deftest builtin-replace-test
+  (testing "replace"
+    (is (= (builtin-replace "abba" "a" "e") "ebbe"))
+    (is (= (builtin-replace "abba" "e" "a") "abba"))
+    (is (= (builtin-replace "ÛnicÖde" "Ö" "o") "Ûnicode"))))
+
+(deftest builtin-strings-reverse-test
+  (testing "strings.reverse"
+    (is (= (builtin-strings-reverse "abba") "abba"))
+    (is (= (builtin-strings-reverse "ÛnicÖde") "edÖcinÛ"))))
+
+(deftest builtin-split-test
+  (testing "split"
+    (is (= (builtin-split "a,b,c" ",") ["a" "b" "c"]))
+    (is (= (builtin-split "abc", ",") ["abc"]))
+    (is (= (builtin-split "abc" "") ["a" "b" "c"]))
+    (is (= (builtin-split "abc" "a") ["" "bc"]))
+    (is (= (builtin-split "åäö" "") ["å" "ä" "ö"]))
+    (is (= (builtin-split ",a,b,,c", ",") ["", "a", "b", "", "c"])))
+  (testing "regex escape"
+    (is (= (builtin-split "a[b[c" "[") ["a" "b" "c"]))
+    (is (= (builtin-split "a*b*c" "*") ["a" "b" "c"])))
+  (testing "string and delim are the same (quirk)"
+    (is (= (builtin-split "abc", "abc") ["" ""]))))
+
+(deftest builtin-startswith-test
+  (testing "startswith"
+    (is (= (builtin-startswith "some text included" "some") true))
+    (is (= (builtin-startswith "ünicÖde everywhere" "ünicÖde") true))
+    (is (= (builtin-startswith "negative test" "positive") false))))
+
+(deftest builtin-substring-test
+  (testing "substring"
+    (is (= (builtin-substring "abcde" 1 3) "bcd"))
+    (is (= (builtin-substring "abcde" 0 5) "abcde"))
+    (is (= (builtin-substring "ünicÖde" 4 1) "Ö"))
+    (is (= (builtin-substring "a" 0 100) "a"))
+    (is (= (builtin-substring "everything" 0 -1) "everything")))
+  (testing "negative offset"
+    (is (thrown-with-msg? BuiltinException #"eval_builtin_error: substring: negative offset" (builtin-substring "a" -1 1)))))
+
+(deftest builtin-trim-prefix-test
+  (testing "trim_prefix"
+    (is (= (builtin-trim-prefix "some text included" "some ") "text included"))
+    (is (= (builtin-trim-prefix "ünicÖde everywhere" "ünicÖde ") "everywhere"))
+    (is (= (builtin-trim-prefix "negative test" "positive") "negative test"))))
+
+(deftest builtin-trim-suffix-test
+  (testing "trim_suffix"
+    (is (= (builtin-trim-suffix "some text included" " included") "some text"))
+    (is (= (builtin-trim-suffix "ünicÖde everywhere" " everywhere") "ünicÖde"))
+    (is (= (builtin-trim-suffix "negative test" "positive") "negative test"))))
+
+(deftest builtin-trim-space-test
+  (testing "upper"
+    (is (= (builtin-trim-space "  foo  ") "foo"))
+    (is (= (builtin-trim-space "foo") "foo"))
+    (is (= (builtin-trim-space "\n\t foo\n \n") "foo"))))
+
+(deftest builtin-upper-test
+  (testing "upper"
+    (is (= (builtin-upper "abba") "ABBA"))
+    (is (= (builtin-upper "ûnicöde") "ÛNICÖDE"))))


### PR DESCRIPTION
Started off with some low-hanging fruits.

Others will be more complicated as we'd need to extend the argument
type checks to work with collections of certain types, or they don't
have an equivalent built-in in clojure. But hey, it's a start :)

Note that I skipped doing args type check tests here as we're planning
to move that into the evaluator.

Signed-off-by: Anders Eknert <anders@eknert.com>