### PR TITLE
Solve issues with bumping clj-kondo

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -10,14 +10,30 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  clj-kondo:
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v3
+    - name: Run clj-kondo linter
+      run: lein clj-kondo
 
+  eastwood:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Run eastwood linter
+      run: lein eastwood
+
+  kibit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Run kibit linter
+      run: lein kibit
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
     - name: Run tests
       run: lein test
-
-    - name: Run linters
-      run: lein lint

--- a/project.clj
+++ b/project.clj
@@ -7,22 +7,25 @@
                  [org.clojure/data.json "2.4.0"]
                  [org.clojure/tools.logging "1.2.4"]
                  [com.google.re2j/re2j "1.6"]]
-  :plugins [[lein-ancient "1.0.0-RC3"]
-            [lein-kibit "0.1.8"]
-            [jonase/eastwood "1.2.3"]
-            [com.github.clj-kondo/lein-clj-kondo "0.1.3"]]
   :repl-options {:init-ns jarl.core}
   :main jarl.core
   :aot [jarl.core jarl.parser jarl.api]
   :direct-linking true
-  :aliases {"lint" ["do" ["eastwood"] ["kibit"] ["clj-kondo" "--lint" "src"]]}
+  :aliases {"clj-kondo" ["with-profile" "+clj-kondo" "clj-kondo" "--lint" "src"]
+            "eastwood" ["with-profile" "+eastwood" "eastwood"]
+            "kibit" ["with-profile" "+kibit" "kibit"]}
   :source-paths ["src/main/clojure"]
   :java-source-paths ["src/main/java"]
   :resource-paths ["src/main/resources"]
   :test-paths ["src/test/clojure"]
-  :profiles {:dev  {:dependencies [[junit/junit "4.13.2"]]}
+  :profiles {:dev  {:dependencies [[junit/junit "4.13.2"]]
+                    :global-vars  {*warn-on-reflection* true}
+                    :plugins      [[lein-ancient "1.0.0-RC3"]]}
              :test {:dependencies      [[org.apache.logging.log4j/log4j-core "2.17.2"]
                                         [org.apache.logging.log4j/log4j-api "2.17.2"]]
                     :java-source-paths ["src/test/java"]
                     :resource-paths    ["src/test/resources"]
-                    :jvm-opts          ["-Dclojure.tools.logging.factory=clojure.tools.logging.impl/log4j2-factory"]}})
+                    :jvm-opts          ["-Dclojure.tools.logging.factory=clojure.tools.logging.impl/log4j2-factory"]}
+             :clj-kondo {:plugins [[com.github.clj-kondo/lein-clj-kondo "0.1.4"]]}
+             :eastwood {:plugins [[jonase/eastwood "1.2.3"]]}
+             :kibit {:plugins [[lein-kibit "0.1.8"]]}})


### PR DESCRIPTION
Isolate plugins using different profiles.

Run linters and tests as separate jobs in order to
have them run in parallel.

Signed-off-by: Anders Eknert <anders@eknert.com>