### PR TITLE
Test/every kw fixes

### DIFF
--- a/src/main/clojure/jarl/eval.clj
+++ b/src/main/clojure/jarl/eval.clj
@@ -308,9 +308,9 @@
   [source-index key-index value-index block-stmt state]
   (log/debugf "ScanStmt - scanning <%d>" source-index)
   (let [source (state/get-local state source-index)]
-    (if (or (nil? source) (not (coll? source)) (empty? source))
+    (if (or (nil? source) (not (coll? source)))             ; OPA IR docs states 'source' may not be an empty collection; but of we 'break' for such, statements like 'every x in [] { x != x }' will be 'undefined'.
       (do
-        (log/debugf "ScanStmt - '%s' is not a collection" source-index)
+        (log/debugf "ScanStmt - '%s' is empty or not a collection" source-index)
         (break state))
       (let [is-set (set? source)]
         (log/trace "ScanStmt - source is list or map")

--- a/src/main/clojure/jarl/eval.clj
+++ b/src/main/clojure/jarl/eval.clj
@@ -308,9 +308,9 @@
   [source-index key-index value-index block-stmt state]
   (log/debugf "ScanStmt - scanning <%d>" source-index)
   (let [source (state/get-local state source-index)]
-    (if (or (nil? source) (not (coll? source)))             ; OPA IR docs states 'source' may not be an empty collection; but of we 'break' for such, statements like 'every x in [] { x != x }' will be 'undefined'.
+    (if (not (coll? source))                                ; OPA IR docs states 'source' may not be an empty collection; but if we 'break' for such, statements like 'every x in [] { x != x }' will be 'undefined'.
       (do
-        (log/debugf "ScanStmt - '%s' is empty or not a collection" source-index)
+        (log/debugf "ScanStmt - '%s' is not a collection" source-index)
         (break state))
       (let [is-set (set? source)]
         (log/trace "ScanStmt - source is list or map")

--- a/src/main/clojure/jarl/eval.clj
+++ b/src/main/clojure/jarl/eval.clj
@@ -213,9 +213,10 @@
   (log/debug "NopStmt - Doing nothing")
   state)
 
-(defn eval-NotEqualStmt [a-index b-index state]
-  (let [a (state/get-value state a-index)
-        b (state/get-value state b-index)
+(defn eval-NotEqualStmt [a-pos b-pos state]
+  (log/tracef "NotEqualStmt - <%s> != <%s>" a-pos b-pos)
+  (let [a (state/get-value state a-pos)
+        b (state/get-value state b-pos)
         result (not= a b)]
     (log/debugf "NotEqualStmt - ('%s' != '%s') == %s" a b result)
     (if result
@@ -320,7 +321,7 @@
           (if (empty? source-indexed)
             (do
               (log/trace "ScanStmt - done")
-              (break state))
+              state)
             (let [entry (first source-indexed)
                   value (get entry 1)
                   key (if is-set value (get entry 0))       ; Rego set entries are indexed by their value

--- a/src/main/clojure/jarl/parser.clj
+++ b/src/main/clojure/jarl/parser.clj
@@ -32,8 +32,9 @@
 (defn make-BlockStmt [{:strs [blocks] :as stmt-info}]
   (log/debug "making BlockStmt stmt")
   (log/tracef "info: %s" stmt-info)
-  (fn [state]
-    (eval/eval-BlockStmt (make-blocks blocks) state)))
+  (let [blocks (make-blocks blocks)]
+    (fn [state]
+      (eval/eval-BlockStmt blocks state))))
 
 (defn make-BreakStmt [{:strs [index]}]
   (log/debug "making BreakStmt stmt")
@@ -168,8 +169,9 @@
 
 (defn make-ScanStmt [{:strs [source key value block]}]
   (log/debug "making ScanStmt stmt")
-  (fn [state]
-    (eval/eval-ScanStmt source key value (make-block block) state)))
+  (let [block (make-block block)]
+    (fn [state]
+      (eval/eval-ScanStmt source key value block state))))
 
 (defn make-WithStmt [stmt-info]
   (log/debug "making WithStmt stmt")
@@ -230,8 +232,9 @@
 
 (defn make-block [{:strs [stmts]}]
   (log/debug "making block")
-  (fn [state]
-    (eval/eval-block (make-stmts stmts) state)))
+  (let [stmts (make-stmts stmts)]
+    (fn [state]
+      (eval/eval-block stmts state))))
 
 (defn make-blocks [blocks-info]
   (log/debug "making blocks")

--- a/src/test/clojure/jarl/compliance_test.clj
+++ b/src/test/clojure/jarl/compliance_test.clj
@@ -30,13 +30,14 @@
 (defn- get-plan [plans name]
   (get (first (filter #(= name (get % 0)) plans)) 1))
 
-(defn- do-test [{:strs [data]
+(defn- do-test [{:strs           [data note]
                  entry-points    "entrypoints"
                  want-results    "want_plan_result"
                  want-error-code "want_error_code"
                  want-error      "want_error"
                  ir              "plan"
-                 :as test-case}]
+                 :as             test-case}]
+  (println "Running test case:" note)
   (let [input (if (contains? test-case "input_term")
                 (json/read-str (get test-case "input_term"))
                 (get test-case "input"))


### PR DESCRIPTION
Fixing `ScanStmt` issues causing test-cases for the `every` keyword to fail.