### PR TITLE
Refactor builtins to take a map as argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,10 @@ https://github.com/google/re2j
 - [x] `bits.lsh`
 - [x] `bits.rsh`
 
+### Conversions
+
+- [x] `to_number`
+
 ### Encoding
 
 - [x] `base64.encode`
@@ -145,6 +149,16 @@ https://github.com/google/re2j
 - [x] `yaml.is_valid`
 - [x] `hex.encode`
 - [x] `hex.decode`
+
+### Deprecated
+
+- [x] `re_match`
+- [x] `cast_array`
+- [x] `cast_set`
+- [x] `cast_string`
+- [x] `cast_boolean`
+- [x] `cast_null`
+- [x] `cast_object`
 
 ## Development
 

--- a/src/main/clojure/jarl/builtins/aggregates.clj
+++ b/src/main/clojure/jarl/builtins/aggregates.clj
@@ -7,29 +7,29 @@
 (defn builtin-count
   "Implementation of count built-in"
   {:builtin "count" :args-types ["any"]}
-  [x]
+  [{[x] :args}]
   (if (string? x)
-    (cp-count x)
+    (cp-count {:args [x]})
     (count x)))
 
 (defn builtin-sum
   "Implementation of sum built-in"
   {:builtin "sum" :args-types ["any"]}
-  [coll]
-  (typed-seq coll #{"number"})
+  [{[coll] :args}]
+  (typed-seq "sum" coll #{"number"})
   (possibly-int (apply + coll)))
 
 (defn builtin-product
   "Implementation of product built-in"
   {:builtin "product" :args-types ["any"]}
-  [coll]
-  (typed-seq coll #{"number"})
+  [{[coll] :args}]
+  (typed-seq "product" coll #{"number"})
   (possibly-int (apply * coll)))
 
 (defn builtin-max
   "Implementation of max built-in"
   {:builtin "max" :args-types ["any"]}
-  [coll]
+  [{[coll] :args}]
   (if (empty? coll)
     (throw (errors/undefined-ex "max on empty collection"))
     (last (sort types/rego-compare coll))))
@@ -37,7 +37,7 @@
 (defn builtin-min
   "Implementation of min built-in"
   {:builtin "min" :args-types ["any"]}
-  [coll]
+  [{[coll] :args}]
   (if (empty? coll)
     (throw (errors/undefined-ex "min on empty collection"))
     (first (sort types/rego-compare coll))))
@@ -45,5 +45,5 @@
 (defn builtin-sort
   "Implementation of sort built-in"
   {:builtin "sort" :args-types ["any"]}
-  [coll]
+  [{[coll] :args}]
   (sort types/rego-compare coll))

--- a/src/main/clojure/jarl/builtins/array.clj
+++ b/src/main/clojure/jarl/builtins/array.clj
@@ -6,21 +6,21 @@
 (defn builtin-concat
   "Implementation of array.concat built-in"
   {:builtin "array.concat" :args-types ["array" "array"]}
-  [a b]
+  [{[a b] :args}]
   (check-args (meta #'builtin-concat) a b)
   (concat a b))
 
 (defn builtin-reverse
   "Implementation of array.reverse built-in"
   {:builtin "array.reverse" :args-types ["array"]}
-  [arr]
+  [{[arr] :args}]
   (check-args (meta #'builtin-reverse) arr)
   (reverse arr))
 
 (defn builtin-slice
   "Implementation of array.slice built-in"
   {:builtin "array.slice" :args-types ["array", "number", "number"]}
-  [arr start stop]
+  [{[arr start stop] :args}]
   (check-args (meta #'builtin-slice) arr start stop)
   (let [start (max start 0)
         stop (min stop (count arr))]

--- a/src/main/clojure/jarl/builtins/bits.clj
+++ b/src/main/clojure/jarl/builtins/bits.clj
@@ -7,23 +7,21 @@
 
 (defn- ensure-pos [builtin-name a b]
   (when (neg? a)
-    (throw (errors/undefined-ex "eval_type_error: %s: operand 1 must be an unsigned integer number but got a negative %s"
-                         builtin-name
-                         (types/java->rego a))))
+    (throw (errors/type-ex "%s: operand 1 must be an unsigned integer number but got a negative %s"
+                           builtin-name
+                           (if (integer? a) "integer" (types/java->rego a)))))
   (when (neg? b)
-    (throw (errors/undefined-ex "eval_type_error: %s: operand 2 must be an unsigned integer number but got a negative %s"
-                         builtin-name
-                         (types/java->rego b)))))
+    (throw (errors/type-ex "%s: operand 2 must be an unsigned integer number but got a negative %s"
+                           builtin-name
+                           (if (integer? b) "integer" (types/java->rego b))))))
 
 (defn- ensure-ints [builtin-name a b]
   (when (non-integer? a)
-    (throw (errors/undefined-ex "eval_type_error: %s: operand 1 must be integer number but got %s"
-                         builtin-name
-                         (types/java->rego a))))
+    (throw (errors/type-ex "%s: operand 1 must be integer number but got %s"
+                           builtin-name (types/java->rego a))))
   (when (non-integer? b)
-    (throw (errors/undefined-ex "eval_type_error: %s: operand 2 must be integer number but got %s"
-                         builtin-name
-                         (types/java->rego b)))))
+    (throw (errors/type-ex "%s: operand 2 must be integer number but got %s"
+                           builtin-name (types/java->rego b)))))
 
 (defn- ensure-pos-ints [builtin-name a b]
   (ensure-ints builtin-name a b)
@@ -32,43 +30,43 @@
 (defn builtin-bits-or
   "Implementation of bits.or built-in"
   {:builtin "bits.or" :args-types ["number" "number"]}
-  [a b]
+  [{[a b] :args}]
   (ensure-ints "bits.or" a b)
   (bit-or a b))
 
 (defn builtin-bits-and
   "Implementation of bits.and built-in"
   {:builtin "bits.and" :args-types ["number" "number"]}
-  [a b]
+  [{[a b] :args}]
   (ensure-ints "bits.and" a b)
   (bit-and a b))
 
 (defn builtin-bits-negate
   "Implementation of bits.negate built-in"
   {:builtin "bits.negate" :args-types ["number"]}
-  [a]
+  [{[a] :args}]
   (when (non-integer? a)
-    (throw (errors/undefined-ex "eval_type_error: bits.negate: operand 1 must be integer number but got %s"
-                                (types/java->rego a))))
+    (throw (errors/type-ex "eval_type_error: bits.negate: operand 1 must be integer number but got %s"
+                           (types/java->rego a))))
   (bit-not a))
 
 (defn builtin-bits-xor
   "Implementation of bits.xor built-in"
   {:builtin "bits.xor" :args-types ["number" "number"]}
-  [a b]
+  [{[a b] :args}]
   (ensure-ints "bits.xor" a b)
   (bit-xor a b))
 
 (defn builtin-bits-lsh
   "Implementation of bits.lsh built-in"
   {:builtin "bits.lsh" :args-types ["number" "number"]}
-  [a b]
+  [{[a b] :args}]
   (ensure-pos-ints "bits.lsh" a b)
   (.shiftLeft (biginteger a) b))
 
 (defn builtin-bits-rsh
   "Implementation of bits.rsh built-in"
   {:builtin "bits.rsh" :args-types ["number" "number"]}
-  [a b]
+  [{[a b] :args}]
   (ensure-pos-ints "bits.rsh" a b)
   (.shiftRight (biginteger a) b))

--- a/src/main/clojure/jarl/builtins/comparison.clj
+++ b/src/main/clojure/jarl/builtins/comparison.clj
@@ -4,37 +4,37 @@
 (defn builtin-equal
   "Implementation of equal (==) built-in"
   {:builtin "==" :args-types ["any" "any"]}
-  [a b]
+  [{[a b] :args}]
   (zero? (types/rego-compare a b)))
 
 (defn builtin-neq
   "Implementation of neq (!=) built-in"
   {:builtin "!=" :args-types ["any" "any"]}
-  [a b]
+  [{[a b] :args}]
   (not (zero? (types/rego-compare a b))))
 
 (defn builtin-lt
   "Implementation of lt (<) built-in"
   {:builtin "<" :args-types ["any" "any"]}
-  [a b]
+  [{[a b] :args}]
   (neg? (types/rego-compare a b)))
 
 (defn builtin-lte
   "Implementation of lte (<=) built-in"
   {:builtin "<=" :args-types ["any" "any"]}
-  [a b]
+  [{[a b] :args}]
   (let [rc (types/rego-compare a b)]
     (or (neg? rc) (zero? rc))))
 
 (defn builtin-gt
   "Implementation of gt (>) built-in"
   {:builtin "<" :args-types ["any" "any"]}
-  [a b]
+  [{[a b] :args}]
   (pos? (types/rego-compare a b)))
 
 (defn builtin-gte
   "Implementation of gte (>=) built-in"
   {:builtin ">=" :args-types ["any" "any"]}
-  [a b]
+  [{[a b] :args}]
   (let [rc (types/rego-compare a b)]
     (or (pos? rc) (zero? rc))))

--- a/src/main/clojure/jarl/builtins/conversions.clj
+++ b/src/main/clojure/jarl/builtins/conversions.clj
@@ -1,0 +1,62 @@
+(ns jarl.builtins.conversions
+  (:require [jarl.exceptions :as errors]
+            [jarl.builtins.utils :refer [check-args]]))
+
+(defn builtin-to-number
+  "Implementation of to_number built-in"
+  {:builtin "to_number" :args-types ["any"]}
+  [{[x] :args}]
+  (if (nil? x)
+    0
+    (condp instance? x
+      Number x
+      Boolean (if (true? x) 1 0)
+      String (let [func (if (.contains ^String x ".") #(Double/parseDouble x) #(Integer/parseInt x))]
+               (try
+                 (func)
+                 (catch Exception _
+                   (throw (errors/builtin-ex "invalid syntax"))))))))
+
+; Deprecated
+
+(defn builtin-cast-array
+  "Implementation of cast_array built-in"
+  {:builtin "cast_array" :args-types [(sorted-set "array" "set")]}
+  [{[x] :args}]
+  (check-args (meta #'builtin-cast-array) x)
+  (vec x))
+
+(defn builtin-cast-set
+  "Implementation of cast_set built-in"
+  {:builtin "cast_set" :args-types [(sorted-set "array" "set")]}
+  [{[x] :args}]
+  (check-args (meta #'builtin-cast-set) x)
+  (set x))
+
+(defn builtin-cast-string
+  "Implementation of cast_string built-in"
+  {:builtin "cast_string" :args-types ["string"]}
+  [{[x] :args}]
+  (check-args (meta #'builtin-cast-string) x)
+  x)
+
+(defn builtin-cast-boolean
+  "Implementation of cast_boolean built-in"
+  {:builtin "cast_boolean" :args-types ["boolean"]}
+  [{[x] :args}]
+  (check-args (meta #'builtin-cast-boolean) x)
+  x)
+
+(defn builtin-cast-null
+  "Implementation of cast_null built-in"
+  {:builtin "cast_null" :args-types ["null"]}
+  [{[x] :args}]
+  (check-args (meta #'builtin-cast-null) x)
+  x)
+
+(defn builtin-cast-object
+  "Implementation of cast_object built-in"
+  {:builtin "cast_object" :args-types ["object"]}
+  [{[x] :args}]
+  (check-args (meta #'builtin-cast-object) x)
+  x)

--- a/src/main/clojure/jarl/builtins/regex.clj
+++ b/src/main/clojure/jarl/builtins/regex.clj
@@ -8,7 +8,7 @@
 (defn builtin-regex-match
   "Implementation of regex.match built-in"
   {:builtin "regex.match" :args-types ["string", "string"]}
-  [pattern ^String value]
+  [{[pattern ^String value] :args}]
   (try
     (-> (Pattern/compile pattern)
         (.matcher value)
@@ -17,31 +17,30 @@
       (throw (errors/builtin-ex (str "eval_builtin_error: regex.match: " (.getMessage e)))))))
 
 ; Deprecated in OPA - only here for test conformance
-(defn builtin-re-match [pattern ^String value]
+(defn builtin-re-match [{[pattern ^String value] :args}]
   (try
-    (builtin-regex-match pattern value)
+    (builtin-regex-match {:args [pattern value]})
     (catch BuiltinException e (str/replace (.getMessage e) #"regex\.match" "re_match"))))
 
 (defn builtin-regex-is-valid
   "Implementation of regex.is_valid built-in"
   {:builtin "regex.is_valid" :args-types ["string"]}
-  [pattern]
-  (try (and (Pattern/compile pattern) true)
-       (catch Exception _ false)))
+  [{[pattern] :args}]
+  (not (errors/throws? #(Pattern/compile pattern))))
 
 (defn builtin-regex-split
   "Implementation of regex.split built-in"
   {:builtin "regex.split" :args-types ["string" "string"]}
-  [pattern ^String value]
+  [{[pattern ^String value] :args}]
   (check-args (meta #'builtin-regex-split) pattern value)
   (-> (Pattern/compile pattern)
-      (.split value)
+      (.split value -1)
       (vec)))
 
 (defn builtin-regex-find-n
   "Implementation of regex.find_n built-in"
   {:builtin "regex.find_n" :args-types ["string" "string" "number"]}
-  [pattern ^String value number]
+  [{[pattern ^String value number] :args}]
   (let [matcher (.matcher (Pattern/compile pattern) value)]
     (loop [i 0
            matches []
@@ -57,5 +56,5 @@
 (defn builtin-regex-find-all-string-submatch-n
   "Implementation of regex.find_all_string_submatch_n built-in"
   {:builtin "regex.find_all_string_submatch_n" :args-types ["string" "string" "number"]}
-  [pattern ^String value number]
+  [{[pattern ^String value number] :args}]
   (throw (errors/builtin-ex "not implemented %s %s %s" pattern value number)))

--- a/src/main/clojure/jarl/builtins/registry.clj
+++ b/src/main/clojure/jarl/builtins/registry.clj
@@ -1,5 +1,6 @@
 (ns jarl.builtins.registry
   (:require [jarl.builtins.comparison :as comparison]
+            [jarl.builtins.conversions :as conversions]
             [jarl.builtins.numbers :as numbers]
             [jarl.builtins.aggregates :as aggregates]
             [jarl.builtins.array :as array]
@@ -48,6 +49,7 @@
 
    "object.get"               objects/builtin-object-get
    "object.remove"            objects/builtin-object-remove
+   "object.filter"            objects/builtin-object-filter
    "object.union"             objects/builtin-object-union
    "object.union_n"           objects/builtin-object-union-n
 
@@ -92,6 +94,14 @@
    "bits.xor"                 bits/builtin-bits-xor
    "bits.lsh"                 bits/builtin-bits-lsh
    "bits.rsh"                 bits/builtin-bits-rsh
+
+   "to_number"                conversions/builtin-to-number
+   "cast_array"               conversions/builtin-cast-array   ; deprecated
+   "cast_set"                 conversions/builtin-cast-set     ; deprecated
+   "cast_string"              conversions/builtin-cast-string  ; deprecated
+   "cast_boolean"             conversions/builtin-cast-boolean ; deprecated
+   "cast_null"                conversions/builtin-cast-null    ; deprecated
+   "cast_object"              conversions/builtin-cast-object  ; deprecated
 
    "base64.encode"            encoding/builtin-base64-encode
    "base64.decode"            encoding/builtin-base64-decode

--- a/src/main/clojure/jarl/builtins/sets.clj
+++ b/src/main/clojure/jarl/builtins/sets.clj
@@ -5,14 +5,14 @@
 (defn builtin-and
   "Implementation of and (&) built-in"
   {:builtin "and" :args-types ["set" "set"]}
-  [a b]
+  [{[a b] :args}]
   (check-args (meta #'builtin-and) a b)
   (set/intersection a b))
 
 (defn builtin-or
   "Implementation of or (|) built-in"
   {:builtin "or" :args-types ["set" "set"]}
-  [a b]
+  [{[a b] :args}]
   (check-args (meta #'builtin-or) a b)
   (set/union a b))
 
@@ -21,7 +21,7 @@
 (defn builtin-intersection
   "Implementation of intersection built-in"
   {:builtin "intersection" :args-types ["set"]}
-  [s]
+  [{[s] :args}]
   (check-args (meta #'builtin-intersection) s)
   (if (empty? s)
     s
@@ -30,6 +30,6 @@
 (defn builtin-union
   "Implementation of union built-in"
   {:builtin "union" :args-types ["set"]}
-  [s]
+  [{[s] :args}]
   (check-args (meta #'builtin-union) s)
   (apply set/union s))

--- a/src/main/clojure/jarl/builtins/strings.clj
+++ b/src/main/clojure/jarl/builtins/strings.clj
@@ -6,7 +6,7 @@
 
 (defn cp-count
   "Count using code points rather than characters"
-  [^String s]
+  [{[^String s] :args}]
   (.codePointCount s 0 (.length s)))
 
 (defn- cp-seq
@@ -21,7 +21,7 @@
 
 (defn- cp-substring
   "Substring using codepoints"
-  [^String s start len]
+  [{[^String s start len] :args}]
   (->> (cp-seq s)
        (drop start)
        (take len)
@@ -58,70 +58,70 @@
 (defn builtin-concat
   "Implementation of concat built-in"
   {:builtin "concat" :args-types ["string" #{"array", "set"}]}
-  [^String delim coll]
+  [{[^String delim coll] :args}]
   (check-args (meta #'builtin-concat) delim coll)
   (str/join delim coll))
 
 (defn builtin-contains
   "Implementation of contains built-in"
   {:builtin "contains" :args-types ["string" "string"]}
-  [^String s ^String search]
+  [{[^String s ^String search] :args}]
   (check-args (meta #'builtin-contains) s search)
   (.contains s search))
 
 (defn builtin-endswith
   "Implementation of endswith built-in"
   {:builtin "endswith" :args-types ["string" "string"]}
-  [s search]
+  [{[s search] :args}]
   (check-args (meta #'builtin-endswith) s search)
   (str/ends-with? s search))
 
 (defn builtin-format-int
   "Implementation of format_int built-in"
   {:builtin "format_int" :args-types ["number" "number"]}
-  [number base]
+  [{[number base] :args}]
   (check-args (meta #'builtin-format-int) number base)
   (Integer/toString number base))
 
 (defn builtin-indexof
   "Implementation of indexof built-in"
   {:builtin "indexof" :args-types ["string" "string"]}
-  [s search]
+  [{[s search] :args}]
   (check-args (meta #'builtin-indexof) s search)
   (or (cp-indexof s search) -1))
 
 (defn builtin-indexof-n
   "Implementation of indexof_n built-in"
   {:builtin "indexof_n" :args-types ["string" "string"]}
-  [s search]
+  [{[s search] :args}]
   (check-args (meta #'builtin-indexof-n) s search)
   (cp-indexof-n s search))
 
 (defn builtin-lower
   "Implementation of lower built-in"
   {:builtin "lower" :args-types ["string"]}
-  [^String s]
+  [{[^String s] :args}]
   (check-args (meta #'builtin-lower) s)
   (.toLowerCase s))
 
 (defn builtin-replace
   "Implementation of replace built-in"
   {:builtin "replace" :args-types ["string" "string" "string"]}
-  [s old new]
+  [{[s old new] :args}]
   (check-args (meta #'builtin-replace) s old new)
   (str/replace s old new))
 
 (defn builtin-strings-reverse
   "Implementation of strings.reverse built-in"
   {:builtin "strings.reverse" :args-types ["string"]}
-  [s]
+  [{[s] :args}]
   (check-args (meta #'builtin-strings-reverse) s)
   (str/reverse s))
 
 (defn builtin-split
   "Implementation of split built-in"
   {:builtin "split" :args-types ["string" "string"]}
-  [s delim]
+  [{[s delim] :args}]
   (check-args (meta #'builtin-split) s)
   (if (= s delim)
     ; Rego quirk? Not sure why this is so, or if there are more cases like this,
@@ -132,7 +132,7 @@
 (defn builtin-startswith
   "Implementation of startswith built-in"
   {:builtin "startswith" :args-types ["string" "string"]}
-  [s search]
+  [{[s search] :args}]
   (check-args (meta #'builtin-startswith) s search)
   (str/starts-with? s search))
 
@@ -141,35 +141,35 @@
 (defn builtin-substring
   "Implementation of substring built-in"
   {:builtin "substring" :args-types ["string" "number" "number"]}
-  [s start len]
+  [{[s start len] :args}]
   (check-args (meta #'builtin-substring) s start len)
   (if (neg-int? start)
-    (throw (errors/builtin-ex "negative offset"))
-    (let [cpc (cp-count s)]
+    (throw (errors/builtin-ex "substring: negative offset"))
+    (let [cpc (cp-count {:args [s]})]
       (if (>= start cpc)
         ""
         (if (neg-int? len)
-          (cp-substring s start cpc)
-          (cp-substring s start len))))))
+          (cp-substring {:args [s start cpc]})
+          (cp-substring {:args [s start len]}))))))
 
 (defn builtin-trim
   "Implementation of trim built-in"
   {:builtin "trim" :args-types ["string" "string"]}
-  [s cutset]
+  [{[s cutset] :args}]
   (check-args (meta #'builtin-trim) s cutset)
   (-> s (trim-left cutset) (trim-right cutset)))
 
 (defn builtin-trim-left
   "Implementation of trim_left built-in"
   {:builtin "trim_left" :args-types ["string" "string"]}
-  [s cutset]
+  [{[s cutset] :args}]
   (check-args (meta #'builtin-trim-left) s cutset)
   (trim-left s cutset))
 
 (defn builtin-trim-prefix
   "Implementation of trim_prefix built-in"
   {:builtin "trim_prefix" :args-types ["string" "string"]}
-  [s prefix]
+  [{[s prefix] :args}]
   (check-args (meta #'builtin-trim-prefix) s prefix)
   (if (str/starts-with? s prefix)
     (subs s (count prefix))
@@ -178,14 +178,14 @@
 (defn builtin-trim-right
   "Implementation of trim_right built-in"
   {:builtin "trim_right" :args-types ["string" "string"]}
-  [s cutset]
+  [{[s cutset] :args}]
   (check-args (meta #'builtin-trim-right) s cutset)
   (trim-right s cutset))
 
 (defn builtin-trim-suffix
   "Implementation of trim_suffix built-in"
   {:builtin "trim_suffix" :args-types ["string" "string"]}
-  [s suffix]
+  [{[s suffix] :args}]
   (check-args (meta #'builtin-trim-suffix) s suffix)
   (if (str/ends-with? s suffix)
     (subs s 0 (- (count s) (count suffix)))
@@ -194,13 +194,13 @@
 (defn builtin-trim-space
   "Implementation of trim_space built-in"
   {:builtin "trim_space" :args-types ["string"]}
-  [s]
+  [{[s] :args}]
   (check-args (meta #'builtin-trim-space) s)
   (str/trim s))
 
 (defn builtin-upper
   "Implementation of upper built-in"
   {:builtin "upper" :args-types ["string"]}
-  [^String s]
+  [{[^String s] :args}]
   (check-args (meta #'builtin-upper) s)
   (.toUpperCase s))

--- a/src/main/clojure/jarl/builtins/types.clj
+++ b/src/main/clojure/jarl/builtins/types.clj
@@ -5,63 +5,63 @@
 (defn builtin-is-number
   "Implementation of is_number built-in"
   {:builtin "is_number" :args-types ["any"]}
-  [x]
+  [{[x] :args}]
   (if (number? x)
     true
-    (throw (errors/undefined-ex "%s is not a number" x))))
+    (throw (errors/undefined-ex "is_number: %s is not a number" x))))
 
 (defn builtin-is-string
   "Implementation of is_string built-in"
   {:builtin "is_string" :args-types ["any"]}
-  [x]
+  [{[x] :args}]
   (if (string? x)
     true
-    (throw (errors/undefined-ex "%s is not a string" x))))
+    (throw (errors/undefined-ex "is_string: %s is not a string" x))))
 
 (defn builtin-is-boolean
   "Implementation of is_boolean built-in"
   {:builtin "is_boolean" :args-types ["any"]}
-  [x]
+  [{[x] :args}]
   (if (boolean? x)
     true
-    (throw (errors/undefined-ex "%s is not a boolean" x))))
+    (throw (errors/undefined-ex "is_boolean: %s is not a boolean" x))))
 
 (defn builtin-is-array
   "Implementation of is_array built-in"
   {:builtin "is_array" :args-types ["any"]}
-  [x]
+  [{[x] :args}]
   (if (vector? x)
     true
-    (throw (errors/undefined-ex "%s is not an array" x))))
+    (throw (errors/undefined-ex "is_array: %s is not an array" x))))
 
 (defn builtin-is-set
   "Implementation of is_set built-in"
   {:builtin "is_set" :args-types ["any"]}
-  [x]
+  [{[x] :args}]
   (if (set? x)
     true
-    (throw (errors/undefined-ex "%s is not a set" x))))
+    (throw (errors/undefined-ex "is_set: %s is not a set" x))))
 
 (defn builtin-is-object
   "Implementation of is_object built-in"
   {:builtin "is_object" :args-types ["any"]}
-  [x]
+  [{[x] :args}]
   (if (map? x)
     true
-    (throw (errors/undefined-ex "%s is not an object" x))))
+    (throw (errors/undefined-ex "is_object: %s is not an object" x))))
 
 (defn builtin-is-null
   "Implementation of is_null built-in"
   {:builtin "is_null" :args-types ["any"]}
-  [x]
+  [{[x] :args}]
   (if (nil? x)
     true
-    (throw (errors/undefined-ex "%s is not null" x))))
+    (throw (errors/undefined-ex "is_null: %s is not null" x))))
 
 (defn builtin-type-name
   "Implementation of type_name built-in"
   {:builtin "type_name" :args-types ["any"]}
-  [x]
+  [{[x] :args}]
   (let [type-name (types/java->rego x)]
     (if (= type-name "floating-point number")
       "number"

--- a/src/main/clojure/jarl/builtins/utils.clj
+++ b/src/main/clojure/jarl/builtins/utils.clj
@@ -44,11 +44,12 @@
 
 (defn typed-seq
   "Ensure that array/set only contains allowed Rego types"
-  [arr-or-set allowed-types]
+  [builtin-name arr-or-set allowed-types]
   (let [allowed-set (set allowed-types)
         allow (if (contains? allowed-set "number") (conj allowed-set "floating-point number") allowed-set)
         forbidden (fn [x] (not (contains? allow (types/java->rego x))))]
     (when-let [violation (first (filter forbidden arr-or-set))]
-      (throw (errors/builtin-ex "operand must be array or set of %s but got array or set containing %s"
-                                (str/join "," allowed-types)
-                                (types/java->rego violation))))))
+      (throw (errors/type-ex "%s: operand must be array or set of %s but got array or set containing %s"
+                             builtin-name
+                             (str/join "," allowed-types)
+                             (types/java->rego violation))))))

--- a/src/main/clojure/jarl/exceptions.clj
+++ b/src/main/clojure/jarl/exceptions.clj
@@ -3,7 +3,8 @@
                             ConflictException
                             MultipleOutputsConflictException
                             TypeException
-                            UndefinedException)))
+                            UndefinedException
+                            JarlException)))
 
 (defn builtin-ex [message & args]
   (BuiltinException. (apply format message args)))
@@ -19,3 +20,36 @@
 
 (defn type-ex [message & args]
   (TypeException. (apply format message args)))
+
+; Must be a better way to do this
+(def rego-ex-type-from-class
+  (memoize (fn [clazz]
+             (condp = clazz
+               BuiltinException (.getType (BuiltinException. ""))
+               ConflictException (.getType (ConflictException. ""))
+               TypeException (.getType (TypeException. ""))
+               ; Unknown class
+               ""))))
+
+(defmacro try-or
+  "Wrap form in try-catch, and return default in case an exception is thrown"
+  [form default]
+  `(try
+     ~form
+     (catch Exception _#
+       ~default)))
+
+(defn throws?
+  "Return true if invoking func throws exception"
+  [func]
+  (= :thrown (try (func) (catch Exception _# :thrown))))
+
+(defn resolve-jarl-exception
+  "Return e if JarlException, or a symbol that may be resolved as one, else nil"
+  [e]
+  (if (and (class? e) (.isAssignableFrom JarlException e))
+    e
+    (when (symbol? e)
+      (let [r (ns-resolve 'jarl.exceptions e)]
+        (when (.isAssignableFrom JarlException r)
+          r)))))

--- a/src/main/clojure/jarl/parser.clj
+++ b/src/main/clojure/jarl/parser.clj
@@ -245,7 +245,7 @@
 
 (defn- stringify-coll-keys [val]
   (cond
-    (or (list? val) (set? val) (vector? val)) (into [] (map stringify-coll-keys val))
+    (or (list? val) (set? val) (vector? val)) (vec (map stringify-coll-keys val))
     (map? val) (loop [pairs (seq val)
                       map {}]
                  (if (empty? pairs)

--- a/src/main/clojure/jarl/state.clj
+++ b/src/main/clojure/jarl/state.clj
@@ -114,11 +114,8 @@
   (merge data (data-from-plan-info plan-info)))
 
 (defn init-state [info input data]
-  (let [local {}
-        local (if-not (nil? input)
-                (assoc local 0 input)
-                local)
-        local (if-not (nil? data)
-                (assoc local 1 (make-data info data))
-                local)]
-    (assoc info :local local)))
+  (-> info
+      (assoc :builtin-context {:time-now-ns (utils/time-now-ns)})
+      (assoc :local (cond-> {}
+                            (some? input) (assoc 0 input)
+                            (some? data) (assoc 1 (make-data info data))))))

--- a/src/main/clojure/jarl/types.clj
+++ b/src/main/clojure/jarl/types.clj
@@ -19,6 +19,9 @@
 (defn bigint? [x]
   (instance? BigInt x))
 
+(defn non-int-float? [x]
+  (not (zero? (mod x 1))))
+
 (defn java->rego
   "Translates provided Java type to equivalent Rego type name"
   [value]
@@ -117,4 +120,4 @@
     :else                         (compare a b)))
 
 (defn rego-equal? [a b]
-  (= (rego-compare a b) 0))
+  (zero? (rego-compare a b)))

--- a/src/main/clojure/jarl/utils.clj
+++ b/src/main/clojure/jarl/utils.clj
@@ -1,4 +1,5 @@
-(ns jarl.utils)
+(ns jarl.utils
+  (:import (java.time Instant)))
 
 ; FIXME: drop "undefined" values? (new 'Undefined' type required)
 (defn map-by-index [array]
@@ -25,5 +26,11 @@
             m
             {})]
     (if ks
-      (assoc m k (indiscriminate-assoc-in (get m k) ks v))
+      (update m k indiscriminate-assoc-in ks v)
       (assoc m k v))))
+
+(defn time-now-ns
+  "Current time nanos — not as precise as its OPA/Go equivalent function, but not in any way that matters"
+  []
+  (let [now (Instant/now)]
+    (+ (* (.getEpochSecond now) 1000000000) (.getNano now))))

--- a/src/main/java/se/fylling/jarl/JarlException.java
+++ b/src/main/java/se/fylling/jarl/JarlException.java
@@ -16,4 +16,12 @@ public class JarlException extends Exception {
     public String getType() {
         return type;
     }
+
+    @Override
+    public String getMessage() {
+        if (!"".equals(type)) {
+            return type + ": " + super.getMessage();
+        }
+        return super.getMessage();
+    }
 }

--- a/src/main/java/se/fylling/jarl/UndefinedException.java
+++ b/src/main/java/se/fylling/jarl/UndefinedException.java
@@ -1,7 +1,7 @@
 package se.fylling.jarl;
 
-public class UndefinedException extends Exception {
+public class UndefinedException extends JarlException {
     public UndefinedException(String message) {
-        super(message);
+        super("", message);
     }
 }

--- a/src/test/clojure/jarl/builtins/aggregates_test.clj
+++ b/src/test/clojure/jarl/builtins/aggregates_test.clj
@@ -1,64 +1,55 @@
 (ns jarl.builtins.aggregates_test
-  (:require [clojure.test :refer [deftest is testing]]
-            [jarl.builtins.aggregates :refer [builtin-count builtin-sum builtin-product
-                                              builtin-max builtin-min builtin-sort]])
-  (:import (se.fylling.jarl BuiltinException)))
+  (:require [clojure.test :refer [deftest]]
+            [test.utils :refer [testing-builtin]])
+  (:import (se.fylling.jarl TypeException)))
 
 (deftest builtin-count-test
-  (testing "count"
-    (is (= (builtin-count []) 0))
-    (is (= (builtin-count [1]) 1))
-    (is (= (builtin-count [1 "a"]) 2))
-    (is (= (builtin-count "abc") 3))
-    (is (= (builtin-count "🍧🍨🧁🍰🍮") 5)))
-  (testing "multiple codepoints"
-    (is (= (builtin-count "🇩🇪") 2))))
+  (testing-builtin "count"
+    [[]]              0
+    [[1]]             1
+    [[1 "a"]]         2
+    ["abc"]           3
+    [(range 11)]      11
+    ["🍧🍨🧁🍰🍮"]   5
+    ["🇩🇪"]            2))
 
 (deftest builtin-sum-test
-  (testing "sum"
-    (is (= (builtin-sum []) 0))
-    (is (= (builtin-sum [0]) 0))
-    (is (= (builtin-sum [1 1]) 2))
-    (is (= (builtin-sum [1 1.9]) 2.9))
-    (is (= (builtin-sum [1.0 1.0]) 2))
-    (is (= (builtin-sum #{3 2 1}) 6)))
-  (testing "negative numbers"
-    (is (= (builtin-sum [-1 -1 -1]) -3))
-    (is (= (builtin-sum [-1.5 1.5 -1]) -1)))
-  (testing "only numbers"
-    (is (thrown-with-msg? BuiltinException
-                          #"operand must be array or set of number but got array or set containing string"
-                          (builtin-sum [1 "3"])))))
+  (testing-builtin "sum"
+    [[]]             0
+    [[0]]            0
+    [[1 1]]          2
+    [[1 1.9]]        2.9
+    [[1.0 1.0]]      2
+    [#{3 2 1}]       6
+    [[-1 -1 -1]]    -3
+    [[-1.5 1.5 -1]] -1
+    [[1 "3"]]       [TypeException "operand must be array or set of number but got array or set containing string"]))
 
 (deftest builtin-product-test
-  (testing "product"
-    (is (= (builtin-product []) 1))
-    (is (= (builtin-product [2]) 2))
-    (is (= (builtin-product [0]) 0))
-    (is (= (builtin-product [1 1]) 1))
-    (is (= (builtin-product [2.5 3]) 7.5))
-    (is (= (builtin-product [10.0 10.000 -2]) -200))
-    (is (= (builtin-product #{3 2 1}) 6)))
-  (testing "only numbers"
-    (is (thrown-with-msg? BuiltinException
-                          #"operand must be array or set of number but got array or set containing string"
-                          (builtin-sum [1 "3"])))))
+  (testing-builtin "product"
+    [[]]                1
+    [[2]]               2
+    [[0]]               0
+    [[1 1]]             1
+    [[2.5 3]]           7.5
+    [[10.0 10.000 -2]]  -200
+    [#{3 2 1}]          6
+    [[1 "3"]]           [TypeException "operand must be array or set of number but got array or set containing string"]))
 
 (deftest builtin-max-test
-  (testing "max"
-    (is (= (builtin-max #{3 2 1}) 3))
-    (is (= (builtin-max [2 1 nil]) 2))
-    (is (= (builtin-max [#{1} "str" 10 {"x" 3} [2.2] 1 nil false]) #{1}))))
+  (testing-builtin "max"
+    [#{3 2 1}]                                  3
+    [[2 1 nil]]                                 2
+    [[#{1} "str" 10 {"x" 3} [2.2] 1 nil false]] #{1}))
 
 (deftest builtin-min-test
-  (testing "min"
-    (is (= (builtin-min #{3 2 1}) 1))
-    (is (= (builtin-min [2 1 nil]) nil))
-    (is (= (builtin-min [#{1} "str" 10 {"x" 3} [2.2] 1 nil false]) nil))))
+  (testing-builtin "min"
+    [#{3 2 1}]                                  1
+    [[2 1 nil]]                                 nil
+    [[#{1} "str" 10 {"x" 3} [2.2] 1 nil false]] nil))
 
 (deftest builtin-sort-test
-  (testing "sort"
-    (is (= (builtin-sort #{3 2 1}) [1 2 3]))
-    (is (= (builtin-sort [2 1 nil]) [nil 1 2]))
-    (is (= (builtin-sort [#{1} "str" 10 {"x" 3} [2.2] 1 nil false])
-           [nil false 1 10 "str" [2.2] {"x" 3} #{1}]))))
+  (testing-builtin "sort"
+    [#{3 2 1}]                                  [1 2 3]
+    [[2 1 nil]]                                 [nil 1 2]
+    [[#{1} "str" 10 {"x" 3} [2.2] 1 nil false]] [nil false 1 10 "str" [2.2] {"x" 3} #{1}]))

--- a/src/test/clojure/jarl/builtins/array_test.clj
+++ b/src/test/clojure/jarl/builtins/array_test.clj
@@ -1,41 +1,30 @@
 (ns jarl.builtins.array_test
-  (:require [clojure.test :refer [deftest is testing]]
-            [jarl.builtins.array :refer [builtin-concat builtin-reverse builtin-slice]])
+  (:require [clojure.test :refer [deftest]]
+            [test.utils :refer [testing-builtin]])
   (:import (se.fylling.jarl TypeException)))
 
 (deftest builtin-concat-test
-  (testing "concat arrays"
-    (is (= (builtin-concat [1 2] [3]) [1 2 3]))
-    (is (= (builtin-concat [1 2 3] []) [1 2 3]))
-    (is (= (builtin-concat [1] ["a"]) [1 "a"]))))
-
-(deftest builtin-concat-test-exceptions
-  (testing "concat non-arrays"
-    (is (thrown-with-msg? TypeException #"array.concat: operand 1 must be array but got string" (builtin-concat "a" [3])))
-    (is (thrown-with-msg? TypeException #"array.concat: operand 2 must be array but got string" (builtin-concat [3] "a")))))
+  (testing-builtin "array.concat"
+    [[1 2] [3]]   [1 2 3]
+    [[1 2 3] []]  [1 2 3]
+    [[1] ["a"]]   [1 "a"]
+    ["a" [3]]     [TypeException "operand 1 must be array but got string"]
+    [[3] "a"]     [TypeException "operand 2 must be array but got string"]))
 
 (deftest builtin-reverse-test
-  (testing "reverse arrays"
-    (is (= (builtin-reverse [1 2 3]) [3 2 1]))
-    (is (= (builtin-reverse ["c" "b" "a"]) ["a" "b" "c"]))
-    (is (= (builtin-reverse []) []))))
-
-(deftest builtin-reverse-test-exceptions
-  (testing "reverse non-arrays"
-    (is (thrown-with-msg? TypeException #"array.reverse: operand 1 must be array but got string" (builtin-reverse "abc")))
-    (is (thrown-with-msg? TypeException #"array.reverse: operand 1 must be array but got number" (builtin-reverse 12345)))))
+  (testing-builtin "array.reverse"
+    [[1 2 3]]         [3 2 1]
+    [["c" "b" "a"]]   ["a" "b" "c"]
+    [[]]              []
+    ["abc"]           [TypeException "operand 1 must be array but got string"]
+    [12345]           [TypeException "operand 1 must be array but got number" ]))
 
 (deftest builtin-slice-test
-  (testing "slice arrays"
-    (is (= [1 2 3] (builtin-slice [1 2 3 4 5] 0 3)))
-    (is (= [3 4] (builtin-slice [1 2 3 4 5] 2 4))))
-  (testing "stop > start"
-    (is (= [] (builtin-slice [1 2 3 4 5] 4 1))))
-  (testing "out of bounds"
-    (is (= [1 2 3] (builtin-slice [1 2 3] -10 10)))))
-
-(deftest builtin-slice-test-exceptions
-  (testing "slice type errors"
-    (is (thrown-with-msg? TypeException #"array.slice: operand 1 must be array but got string" (builtin-slice "10" -10 10)))
-    (is (thrown-with-msg? TypeException #"array.slice: operand 2 must be integer but got floating-point number" (builtin-slice [10] 10.01 10)))
-    (is (thrown-with-msg? TypeException #"array.slice: operand 3 must be number but got string" (builtin-slice [10] 0 "f")))))
+  (testing-builtin "array.slice"
+    [[1 2 3 4 5] 0 3]     [1 2 3]
+    [[1 2 3 4 5] 2 4]     [3 4]
+    [[1 2 3 4 5] 4 1]     []
+    [[1 2 3] -10 10]      [1 2 3]
+    ["10" -10 10]         [TypeException "operand 1 must be array but got string"]
+    [[10] 10.01 10]       [TypeException "operand 2 must be integer but got floating-point number"]
+    [[10] 0 "f"]          [TypeException "operand 3 must be number but got string"]))

--- a/src/test/clojure/jarl/builtins/bits_test.clj
+++ b/src/test/clojure/jarl/builtins/bits_test.clj
@@ -1,97 +1,62 @@
 (ns jarl.builtins.bits_test
-  (:require [clojure.test :refer [deftest is testing]]
-            [jarl.builtins.bits :refer [builtin-bits-or builtin-bits-and builtin-bits-negate
-                                        builtin-bits-xor builtin-bits-lsh builtin-bits-rsh]])
-  (:import (se.fylling.jarl UndefinedException)))
+  (:require [clojure.test :refer [deftest]]
+            [test.utils :refer [testing-builtin]])
+  (:import (se.fylling.jarl TypeException)))
 
 (deftest builtin-bits-or-test
-  (testing "bits.or"
-    (is (= (builtin-bits-or 13 10) 15))
-    (is (= (builtin-bits-or 10 -10) -2))
-    (is (= (builtin-bits-or -10 -10) -10)))
-  (testing "non-integers"
-    (is (thrown-with-msg? UndefinedException
-                          #"eval_type_error: bits.or: operand 1 must be integer number but got floating-point number"
-                          (builtin-bits-or 10.1 1)))
-    (is (thrown-with-msg? UndefinedException
-                          #"eval_type_error: bits.or: operand 2 must be integer number but got floating-point number"
-                          (builtin-bits-or 2 2.22)))))
+  (testing-builtin "bits.or"
+    [13 10]   15
+    [10 -10]  -2
+    [-10 -10] -10
+    [10.1 1]  [TypeException "operand 1 must be integer number but got floating-point number"]
+    [2 2.22]  [TypeException "operand 2 must be integer number but got floating-point number"]))
 
 (deftest builtin-bits-and-test
-  (testing "bits.and"
-    (is (= (builtin-bits-and 13 10) 8))
-    (is (= (builtin-bits-and 10 -10) 2))
-    (is (= (builtin-bits-and 100 5) 4)))
-  (testing "non-integers"
-    (is (thrown-with-msg? UndefinedException
-                          #"eval_type_error: bits.and: operand 1 must be integer number but got floating-point number"
-                          (builtin-bits-and 10.1 1)))
-    (is (thrown-with-msg? UndefinedException
-                          #"eval_type_error: bits.and: operand 2 must be integer number but got floating-point number"
-                          (builtin-bits-and 2 2.22)))))
+  (testing-builtin "bits.and"
+    [13 10]  8
+    [10 -10] 2
+    [100 5]  4
+    [10.1 1] [TypeException "operand 1 must be integer number but got floating-point number"]
+    [2 2.22] [TypeException "operand 2 must be integer number but got floating-point number"]))
 
 (deftest builtin-bits-negate-test
-  (testing "bits.negate"
-    (is (= (builtin-bits-negate 100) -101))
-    (is (= (builtin-bits-negate 2) -3))
-    (is (= (builtin-bits-negate -33) 32)))
-  (testing "non-integers"
-    (is (thrown-with-msg? UndefinedException
-                          #"eval_type_error: bits.negate: operand 1 must be integer number but got floating-point number"
-                          (builtin-bits-negate 10.1)))))
+  (testing-builtin "bits.negate"
+    [100]  -101
+    [2]    -3
+    [-33]  32
+    [10.1] [TypeException "operand 1 must be integer number but got floating-point number"]))
 
 (deftest builtin-bits-xor-test
-  (testing "bits.xor"
-    (is (= (builtin-bits-xor 10 20) 30))
-    (is (= (builtin-bits-xor 10 -20) -26))
-    (is (= (builtin-bits-xor -10 -20) 26)))
-  (testing "non-integers"
-    (is (thrown-with-msg? UndefinedException
-                          #"eval_type_error: bits.xor: operand 1 must be integer number but got floating-point number"
-                          (builtin-bits-xor 10.1 1)))
-    (is (thrown-with-msg? UndefinedException
-                          #"eval_type_error: bits.xor: operand 2 must be integer number but got floating-point number"
-                          (builtin-bits-xor 2 2.22)))))
+  (testing-builtin "bits.xor"
+    [10 20]   30
+    [10 -20]  -26
+    [-10 -20] 26
+    [10.1 1]  [TypeException "operand 1 must be integer number but got floating-point number"]
+    [2 2.22]  [TypeException "operand 2 must be integer number but got floating-point number"]))
 
 ; Note: Clojure shift left/right functions take negative numbers, Rego does not
 
 (deftest builtin-bits-lsh-test
-  (testing "bits.lsh"
-    (is (= (builtin-bits-lsh 10 20) 10485760))
-    (is (= (builtin-bits-lsh 1 4) 16))
-    (is (= (builtin-bits-lsh 1 8) 256))
-    (is (= (builtin-bits-lsh 9223372036854775807 1) 18446744073709551614N)))
-  (testing "non-integers"
-    (is (thrown-with-msg? UndefinedException
-                          #"eval_type_error: bits.lsh: operand 1 must be integer number but got floating-point number"
-                          (builtin-bits-lsh 10.1 1)))
-    (is (thrown-with-msg? UndefinedException
-                          #"eval_type_error: bits.lsh: operand 2 must be integer number but got floating-point number"
-                          (builtin-bits-lsh 2 2.22))))
-  (testing "negative integers"
-    (is (thrown-with-msg? UndefinedException
-                          #"eval_type_error: bits.lsh: operand 1 must be an unsigned integer number but got a negative number"
-                          (builtin-bits-lsh -10 1)))
-    (is (thrown-with-msg? UndefinedException
-                          #"eval_type_error: bits.lsh: operand 2 must be an unsigned integer number but got a negative number"
-                          (builtin-bits-lsh 2 -2)))))
+  (testing-builtin "bits.lsh"
+    [10 20]                 10485760
+    [1 4]                   16
+    [1 8]                   256
+    [9223372036854775807 1] 18446744073709551614N
+    ; non-integers
+    [10.1 1] [TypeException "operand 1 must be integer number but got floating-point number"]
+    [2 2.22] [TypeException "operand 2 must be integer number but got floating-point number"]
+    ; negative integers
+    [-10 1]  [TypeException "operand 1 must be an unsigned integer number but got a negative number"]
+    [2 -2]   [TypeException "operand 2 must be an unsigned integer number but got a negative number"]))
 
 (deftest builtin-bits-rsh-test
-  (testing "bits.rsh"
-    (is (= (builtin-bits-rsh 10 20) 0))
-    (is (= (builtin-bits-rsh 10 3) 1))
-    (is (= (builtin-bits-rsh 100 3) 12)))
-  (testing "non-integers"
-    (is (thrown-with-msg? UndefinedException
-                          #"eval_type_error: bits.rsh: operand 1 must be integer number but got floating-point number"
-                          (builtin-bits-rsh 10.1 1)))
-    (is (thrown-with-msg? UndefinedException
-                          #"eval_type_error: bits.rsh: operand 2 must be integer number but got floating-point number"
-                          (builtin-bits-rsh 2 2.22))))
-  (testing "negative integers"
-    (is (thrown-with-msg? UndefinedException
-                          #"eval_type_error: bits.rsh: operand 1 must be an unsigned integer number but got a negative number"
-                          (builtin-bits-rsh -10 1)))
-    (is (thrown-with-msg? UndefinedException
-                          #"eval_type_error: bits.rsh: operand 2 must be an unsigned integer number but got a negative number"
-                          (builtin-bits-rsh 2 -2)))))
+  (testing-builtin "bits.rsh"
+    [10 20] 0
+    [10 3]  1
+    [100 3] 12
+    ; non-integers
+    [10.1 1] [TypeException "operand 1 must be integer number but got floating-point number"]
+    [2 2.22] [TypeException "operand 2 must be integer number but got floating-point number"]
+    ; negative integers
+    [-10 1]  [TypeException "operand 1 must be an unsigned integer number but got a negative number"]
+    [2 -2]   [TypeException "operand 2 must be an unsigned integer number but got a negative number"]))

--- a/src/test/clojure/jarl/builtins/comparison_test.clj
+++ b/src/test/clojure/jarl/builtins/comparison_test.clj
@@ -1,174 +1,173 @@
 (ns jarl.builtins.comparison_test
-  (:require [clojure.test :refer [deftest is testing]]
-            [jarl.builtins.comparison :refer [builtin-equal builtin-neq builtin-lt builtin-lte builtin-gt
-                                              builtin-gte]]))
+  (:require [clojure.test :refer [deftest]]
+            [test.utils :refer [testing-builtin]]))
 
 (deftest builtin-equal-test
-  (testing "numbers"
-    (is (= (builtin-equal 1 1) true))
-    (is (= (builtin-equal 1 1.0) true))
-    (is (= (builtin-equal -3.334 -3.3340000) true))
-    (is (= (builtin-equal 3.00000000000001 3) false))
-    (is (= (builtin-equal 3 "3") false)))
-  (testing "strings"
-    (is (= (builtin-equal "a" "a") true))
-    (is (= (builtin-equal "a" "A") false))
-    (is (= (builtin-equal "a" "b") false))
-    (is (= (builtin-equal "å" "å") true))
-    (is (= (builtin-equal "🇸🇪" "🇸🇪") true))
-    (is (= (builtin-equal "foo bar baz\t" "foo bar baz\t") true)))
-  (testing "objects"
-    (is (= (builtin-equal {"foo" "bar"} {"foo" "bar"}) true))
-    (is (= (builtin-equal {"foo" "bar"} {"foo" "bar" "bar" "baz"}) false))
-    (is (= (builtin-equal {"foo" "bar" "bar" "baz"} {"bar" "baz" "foo" "bar"}) true))
-    (is (= (builtin-equal {"foo" ["bar" 1]} {"foo" ["bar" 1]}) true))
-    (is (= (builtin-equal {"foo" 1} {"foo" 1.0}) true)))
-  (testing "arrays"
-    (is (= (builtin-equal ["foo" "bar"] ["foo" "bar"]) true))
-    (is (= (builtin-equal ["bar" "foo"] ["foo" "bar"]) false))
-    (is (= (builtin-equal ["fåäö" "båäör"] ["fåäö" "båäör"]) true))
-    (is (= (builtin-equal ["a" 1 [2] "b"] ["a" 1 [2] "b"]) true)))
-  (testing "booleans"
-    (is (= (builtin-equal true true) true))
-    (is (= (builtin-equal false false) true))
-    (is (= (builtin-equal true false) false)))
-  (testing "null"
-    (is (= (builtin-equal nil nil) true))
-    (is (= (builtin-equal nil " ") false))))
+  (testing-builtin "equal"
+    ; numbers
+    [1 1]                true
+    [1 1.0]              true
+    [-3.334 -3.3340000]  true
+    [3.00000000000001 3] false
+    [3 "3"]              false
+    ; strings
+    ["a" "a"]                         true
+    ["a" "b"]                         false
+    ["å" "å"]                         true
+    ["🇸🇪" "🇸🇪"]                       true
+    ["foo bar baz\t" "foo bar baz\t"] true
+    ; objects
+    [{"foo" "bar"} {"foo" "bar"}]                         true
+    [{"foo" "bar"} {"foo" "bar" "bar" "baz"}]             false
+    [{"foo" "bar" "bar" "baz"} {"bar" "baz" "foo" "bar"}] true
+    [{"foo" ["bar" 1]} {"foo" ["bar" 1]}]                 true
+    [{"foo" 1} {"foo" 1.0}]                               true
+    ; arrays
+    [["foo" "bar"] ["foo" "bar"]]       true
+    [["bar" "foo"] ["foo" "bar"]]       false
+    [["fåäö" "båäör"] ["fåäö" "båäör"]] true
+    [["a" 1 [2] "b"] ["a" 1 [2] "b"]]   true
+    ; booleans
+    [true true]   true
+    [false false] true
+    [true false]  false
+    ; null
+    [nil nil] true
+    [nil " "] false))
 
 (deftest builtin-neq-test
-  (testing "numbers"
-    (is (= (builtin-neq 1 2) true))
-    (is (= (builtin-neq 1 1) false))
-    (is (= (builtin-neq 1 1.0) false))
-    (is (= (builtin-neq -3.334 -3.3340000) false)))
-  (testing "bigint"
-    (is (= (builtin-neq 28857836529306024611913 28857836529306024611912) true)))
-  (testing "strings"
-    (is (= (builtin-neq "a" "a") false))
-    (is (= (builtin-neq "a" "A") true))
-    (is (= (builtin-neq "å" "å") false))
-    (is (= (builtin-neq "🇸🇪" "🇸🇪") false))
-    (is (= (builtin-neq "foo bar baz\t" "foo bar baz\t") false)))
-  (testing "objects"
-    (is (= (builtin-neq {"foo" "bar"} {"foo" "bar"}) false))
-    (is (= (builtin-neq {"foo" ["bar" 1]} {"foo" ["bar" 1]}) false)))
-  (testing "arrays"
-    (is (= (builtin-neq ["foo" "bar"] ["foo" "bar"]) false))
-    (is (= (builtin-neq ["bar" "foo"] ["foo" "bar"]) true))
-    (is (= (builtin-neq ["fåäö" "båäör"] ["fåäö" "båäör"]) false))
-    (is (= (builtin-neq ["a" 1 [2] "b"] ["a" 1 [2] "b"]) false)))
-  (testing "boolean"
-    (is (= (builtin-neq true true) false))
-    (is (= (builtin-neq false false) false))
-    (is (= (builtin-neq true false) true)))
-  (testing "null"
-    (is (= (builtin-neq nil nil) false))
-    (is (= (builtin-neq nil " ") true))))
+  (testing-builtin "neq"
+    [1 2] true
+    [1 1] false
+    [1 1.0] false
+    [-3.334 -3.3340000] false
+    ; bigint
+    [28857836529306024611913 28857836529306024611912] true
+    ; strings
+    ["a" "a"] false
+    ["a" "A"] true
+    ["å" "å"] false
+    ["🇸🇪" "🇸🇪"] false
+    ["foo bar baz\t" "foo bar baz\t"] false
+    ; objects
+    [{"foo" "bar"} {"foo" "bar"}] false
+    [{"foo" ["bar" 1]} {"foo" ["bar" 1]}] false
+    ; arrays
+    [["foo" "bar"] ["foo" "bar"]] false
+    [["bar" "foo"] ["foo" "bar"]] true
+    [["fåäö" "båäör"] ["fåäö" "båäör"]] false
+    [["a" 1 [2] "b"] ["a" 1 [2] "b"]] false
+    ; booleans
+    [true true] false
+    [false false] false
+    [true false] true
+    ; null
+    [nil nil] false
+    [nil " "] true))
 
 (deftest builtin-lt-test
-  (testing "numbers"
-    (is (= (builtin-lt 1 1) false))
-    (is (= (builtin-lt 1.001 1.001) false))
-    (is (= (builtin-lt 1.001 1.002) true))
-    (is (= (builtin-lt 2 1) false))
-    (is (= (builtin-lt 1 2) true))
-    (is (= (builtin-lt 1.9 2) true))
-    (is (= (builtin-lt -2 2) true)))
-  (testing "strings"
-    (is (= (builtin-lt "a" "a") false))
-    (is (= (builtin-lt "b" "a") false))
-    (is (= (builtin-lt "a" "b") true)))
-  (testing "objects"
-    (is (= (builtin-lt {"foo" "bar"} {"foo" "bar"}) false))
-    (is (= (builtin-lt {"foo" 1} {"foo" 2}) true))
-    (is (= (builtin-lt {"foo" 1} {"foo" 1 "bar" 2}) false))
-    (is (= (builtin-lt {"foo" {"x" 1}} {"foo" {"x" 2}}) true))
-    (is (= (builtin-lt {"foo" [1 2]} {"foo" [1 2 3]}) true)))
-  (testing "objects-different-keys"
-    (is (= (builtin-lt {"foo" 1} {"bar" 2}) false)))
-  (testing "arrays"
-    (is (= (builtin-lt ["foo" "bar"] ["foo" "bar"]) false))
-    (is (= (builtin-lt ["a" "b"] ["a" "c"]) true))
-    (is (= (builtin-lt [1 2 3] [1 2 4]) true))
-    (is (= (builtin-lt [1 2 3] [1 2 "a"]) true))
-    (is (= (builtin-lt [1 2 3] [1 2 3 -100]) true))
-    (is (= (builtin-lt [[1 2]] [[1 3]]) true)))
-  (testing "sets"
-    (is (= (builtin-lt #{1} #{1}) false))
-    (is (= (builtin-lt #{1} #{2}) true))
-    (is (= (builtin-lt #{1 2} #{3}) true))
-    (is (= (builtin-lt #{100} #{1 10001}) false))
-    (is (= (builtin-lt #{{"x" 1}} #{{"x" 2}}) true)))
-  (testing "booleans"
-    (is (= (builtin-lt true true) false))
-    (is (= (builtin-lt true false) false))
-    (is (= (builtin-lt false true) true))
-    (is (= (builtin-lt false 0) true))
-    (is (= (builtin-lt true 0) true)))
-  (testing "null"
-    (is (= (builtin-lt nil nil) false))
-    (is (= (builtin-lt nil 1) true))
-    (is (= (builtin-lt nil "") true))
-    (is (= (builtin-lt nil false) true))))
+  (testing-builtin "lt"
+    [1 1] false
+    [1.001 1.001] false
+    [1.001 1.002] true
+    [2 1] false
+    [1 2] true
+    [1.9 2] true
+    [-2 2] true
+    ; strings
+    ["a" "a"] false
+    ["b" "a"] false
+    ["a" "b"] true
+    ; objects
+    [{"foo" "bar"} {"foo" "bar"}] false
+    [{"foo" 1} {"foo" 2}] true
+    [{"foo" 1} {"foo" 1 "bar" 2}] false
+    [{"foo" {"x" 1}} {"foo" {"x" 2}}] true
+    [{"foo" [1 2]} {"foo" [1 2 3]}] true
+    ; objects-different-keys
+    [{"foo" 1} {"bar" 2}] false
+    ; arrays
+    [["foo" "bar"] ["foo" "bar"]] false
+    [["a" "b"] ["a" "c"]] true
+    [[1 2 3] [1 2 4]] true
+    [[1 2 3] [1 2 "a"]] true
+    [[1 2 3] [1 2 3 -100]] true
+    [[[1 2]] [[1 3]]] true
+    ; sets
+    [#{1} #{1}] false
+    [#{1} #{2}] true
+    [#{1 2} #{3}] true
+    [#{100} #{1 10001}] false
+    [#{{"x" 1}} #{{"x" 2}}] true
+    ; booleans
+    [true true] false
+    [true false] false
+    [false true] true
+    [false 0] true
+    [true 0] true
+    ; null
+    [nil nil] false
+    [nil 1] true
+    [nil ""] true
+    [nil false] true))
 
 (deftest builtin-gt-test
-  (testing "numbers"
-    (is (= (builtin-gt 1 1) false))
-    (is (= (builtin-gt 1.001 1.001) false))
-    (is (= (builtin-gt 1.001 1.002) false))
-    (is (= (builtin-gt 2 1) true))
-    (is (= (builtin-gt 1 2) false))
-    (is (= (builtin-gt 1.9 2) false))
-    (is (= (builtin-gt -2 2) false)))
-  (testing "strings"
-    (is (= (builtin-gt "a" "a") false))
-    (is (= (builtin-gt "b" "a") true))
-    (is (= (builtin-gt "a" "b") false)))
-  (testing "objects"
-    (is (= (builtin-gt {"foo" "bar"} {"foo" "bar"}) false))
-    (is (= (builtin-gt {"foo" 1} {"foo" 2}) false))
-    (is (= (builtin-gt {"foo" 1} {"foo" 1 "bar" 2}) true))
-    (is (= (builtin-gt {"foo" {"x" 1}} {"foo" {"x" 2}}) false))
-    (is (= (builtin-gt {"foo" [1 2]} {"foo" [1 2 3]}) false)))
-  (testing "objects-different-keys"
-    (is (= (builtin-gt {"foo" 1} {"bar" 2}) true)))
-  (testing "arrays"
-    (is (= (builtin-gt ["foo" "bar"] ["foo" "bar"]) false))
-    (is (= (builtin-gt ["a" "b"] ["a" "c"]) false))
-    (is (= (builtin-gt [1 2 3] [1 2 4]) false))
-    (is (= (builtin-gt [1 2 3] [1 2 "a"]) false))
-    (is (= (builtin-gt [1 2 3] [1 2 3 -100]) false))
-    (is (= (builtin-gt [[1 2]] [[1 3]]) false)))
-  (testing "sets"
-    (is (= (builtin-gt #{1} #{1}) false))
-    (is (= (builtin-gt #{1} #{2}) false))
-    (is (= (builtin-gt #{1 2} #{3}) false))
-    (is (= (builtin-gt #{100} #{1 10001}) true))
-    (is (= (builtin-gt #{{"x" 1}} #{{"x" 2}}) false)))
-  (testing "booleans"
-    (is (= (builtin-gt true true) false))
-    (is (= (builtin-gt true false) true))
-    (is (= (builtin-gt false true) false))
-    (is (= (builtin-gt false 0) false))
-    (is (= (builtin-gt true 0) false)))
-  (testing "null"
-    (is (= (builtin-gt nil nil) false))
-    (is (= (builtin-gt nil 1) false))
-    (is (= (builtin-gt nil "") false))
-    (is (= (builtin-gt nil false) false))))
+  (testing-builtin "gt"
+    [1 1] false
+    [1.001 1.001] false
+    [1.001 1.002] false
+    [2 1] true
+    [1 2] false
+    [1.9 2] false
+    [-2 2] false
+    ; strings
+    ["a" "a"] false
+    ["b" "a"] true
+    ["a" "b"] false
+    ; objects
+    [{"foo" "bar"} {"foo" "bar"}] false
+    [{"foo" 1} {"foo" 2}] false
+    [{"foo" 1} {"foo" 1 "bar" 2}] true
+    [{"foo" {"x" 1}} {"foo" {"x" 2}}] false
+    [{"foo" [1 2]} {"foo" [1 2 3]}] false
+    ; objects-different-keys
+    [{"foo" 1} {"bar" 2}] true
+    ; arrays
+    [["foo" "bar"] ["foo" "bar"]] false
+    [["a" "b"] ["a" "c"]] false
+    [[1 2 3] [1 2 4]] false
+    [[1 2 3] [1 2 "a"]] false
+    [[1 2 3] [1 2 3 -100]] false
+    [[[1 2]] [[1 3]]] false
+    ; sets
+    [#{1} #{1}] false
+    [#{1} #{2}] false
+    [#{1 2} #{3}] false
+    [#{100} #{1 10001}] true
+    [#{{"x" 1}} #{{"x" 2}}] false
+    ; booleans
+    [true true] false
+    [true false] true
+    [false true] false
+    [false 0] false
+    [true 0] false
+    ; null
+    [nil nil] false
+    [nil 1] false
+    [nil ""] false
+    [nil false] false))
 
 ; These are already tested by virtue of rego-compare and the tests above
 ; Just sanity checking here..
 
 (deftest builtin-lte-test
-  (testing "numbers"
-    (is (= (builtin-lte 1 1) true))
-    (is (= (builtin-lte 1 2) true))
-    (is (= (builtin-lte 2 1) false))))
+  (testing-builtin "lte"
+    [1 1] true
+    [1 2] true
+    [2 1] false))
 
 (deftest builtin-gte-test
-  (testing "numbers"
-    (is (= (builtin-gte 1 1) true))
-    (is (= (builtin-gte 1 2) false))
-    (is (= (builtin-gte 2 1) true))))
+  (testing-builtin "gte"
+    [1 1] true
+    [1 2] false
+    [2 1] true))

--- a/src/test/clojure/jarl/builtins/conversions_test.clj
+++ b/src/test/clojure/jarl/builtins/conversions_test.clj
@@ -1,0 +1,13 @@
+(ns jarl.builtins.conversions-test
+  (:require [clojure.test :refer [deftest]]
+            [test.utils :refer [testing-builtin]]))
+
+(deftest to-number-test
+  (testing-builtin "to_number"
+    ["1"]       1
+    ["1.12345"] 1.12345
+    ["-22"]     -22
+    ["-3.14"]   -3.14
+    [true]      1
+    [false]     0
+    [nil]       0))

--- a/src/test/clojure/jarl/builtins/encoding_test.clj
+++ b/src/test/clojure/jarl/builtins/encoding_test.clj
@@ -1,103 +1,97 @@
 (ns jarl.builtins.encoding_test
-  (:require [clojure.test :refer [deftest is testing]]
-            [jarl.builtins.encoding :refer [builtin-base64-encode builtin-base64-decode builtin-base64-url-encode
-                                            builtin-base64-url-encode-no-pad builtin-base64-url-decode
-                                            builtin-url-query-encode builtin-url-query-decode builtin-json-unmarshal
-                                            builtin-json-is-valid builtin-hex-encode builtin-hex-decode
-                                            builtin-yaml-marshal builtin-yaml-unmarshal builtin-yaml-is-valid]])
+  (:require [clojure.test :refer [deftest]]
+            [test.utils :refer [testing-builtin]])
   (:import (se.fylling.jarl BuiltinException)))
 
 (deftest builtin-base64-encode-test
-  (testing "base64.encode"
-    (is (= (builtin-base64-encode "abc123") "YWJjMTIz"))
-    (is (= (builtin-base64-encode "målarfärg") "bcOlbGFyZsOkcmc="))
-    (is (= (builtin-base64-encode "The Rego Playground") "VGhlIFJlZ28gUGxheWdyb3VuZA=="))
-    (is (= (builtin-base64-encode "😆") "8J+Yhg=="))))
+  (testing-builtin "base64.encode"
+    ["abc123"] "YWJjMTIz"
+    ["målarfärg"] "bcOlbGFyZsOkcmc="
+    ["The Rego Playground"] "VGhlIFJlZ28gUGxheWdyb3VuZA=="
+    ["😆"] "8J+Yhg=="))
 
 (deftest builtin-base64-decode-test
-  (testing "base64.decode"
-    (is (= (builtin-base64-decode "YWJjMTIz") "abc123"))
-    (is (= (builtin-base64-decode "bcOlbGFyZsOkcmc=") "målarfärg"))
-    (is (= (builtin-base64-decode "VGhlIFJlZ28gUGxheWdyb3VuZA==") "The Rego Playground"))
-    (is (= (builtin-base64-decode "8J+Yhg==") "😆"))))
+  (testing-builtin "base64.decode"
+    ["YWJjMTIz"] "abc123"
+    ["bcOlbGFyZsOkcmc="] "målarfärg"
+    ["VGhlIFJlZ28gUGxheWdyb3VuZA=="] "The Rego Playground"
+    ["8J+Yhg=="] "😆"))
 
 (deftest builtin-base64-url-encode-test
-  (testing "base64url.encode"
-    (is (= (builtin-base64-url-encode "abc123") "YWJjMTIz"))
-    (is (= (builtin-base64-url-encode "målarfärg") "bcOlbGFyZsOkcmc="))
-    (is (= (builtin-base64-url-encode "The Rego Playground") "VGhlIFJlZ28gUGxheWdyb3VuZA=="))
-    (is (= (builtin-base64-url-encode "😆") "8J-Yhg==")))) ; + replaced with -
+  (testing-builtin "base64url.encode"
+    ["abc123"] "YWJjMTIz"
+    ["målarfärg"] "bcOlbGFyZsOkcmc="
+    ["The Rego Playground"] "VGhlIFJlZ28gUGxheWdyb3VuZA=="
+    ["😆"] "8J-Yhg==")) ; + replaced with -
 
 (deftest builtin-base64-url-encode-no-pad-test
-  (testing "base64url.encode_no_pad"
-    (is (= (builtin-base64-url-encode-no-pad "abc123") "YWJjMTIz"))
-    (is (= (builtin-base64-url-encode-no-pad "målarfärg") "bcOlbGFyZsOkcmc"))
-    (is (= (builtin-base64-url-encode-no-pad "The Rego Playground") "VGhlIFJlZ28gUGxheWdyb3VuZA"))
-    (is (= (builtin-base64-url-encode-no-pad "😆") "8J-Yhg")))) ; + replaced with -
+  (testing-builtin "base64url.encode_no_pad"
+    ["abc123"] "YWJjMTIz"
+    ["målarfärg"] "bcOlbGFyZsOkcmc"
+    ["The Rego Playground"] "VGhlIFJlZ28gUGxheWdyb3VuZA"
+    ["😆"] "8J-Yhg")) ; + replaced with -
 
 (deftest builtin-base64-url-decode-test
-  (testing "base64url.decode"
-    (is (= (builtin-base64-url-decode "YWJjMTIz") "abc123"))
-    (is (= (builtin-base64-url-decode "bcOlbGFyZsOkcmc=") "målarfärg"))
-    (is (= (builtin-base64-url-decode "VGhlIFJlZ28gUGxheWdyb3VuZA==") "The Rego Playground"))
-    (is (= (builtin-base64-url-decode "8J-Yhg==") "😆"))))
+  (testing-builtin "base64url.decode"
+    ["YWJjMTIz"] "abc123"
+    ["bcOlbGFyZsOkcmc="] "målarfärg"
+    ["VGhlIFJlZ28gUGxheWdyb3VuZA=="] "The Rego Playground"
+    ["8J-Yhg=="] "😆"))
 
 (deftest builtin-url-query-encode-test
-  (testing "urlquery.encode"
-    (is (= (builtin-url-query-encode "foo bar") "foo+bar"))
-    (is (= (builtin-url-query-encode "blå") "bl%C3%A5"))
-    (is (= (builtin-url-query-encode "/&=") "%2F%26%3D"))))
+  (testing-builtin "urlquery.encode"
+    ["foo bar"] "foo+bar"
+    ["blå"] "bl%C3%A5"
+    ["/&="] "%2F%26%3D"))
 
 (deftest builtin-url-query-decode-test
-  (testing "urlquery.decode"
-    (is (= (builtin-url-query-decode "foo+bar") "foo bar"))
-    (is (= (builtin-url-query-decode "bl%C3%A5") "blå"))
-    (is (= (builtin-url-query-decode "%2F%26%3D") "/&="))))
+  (testing-builtin "urlquery.decode"
+    ["foo+bar"] "foo bar"
+    ["bl%C3%A5"] "blå"
+    ["%2F%26%3D"] "/&="))
 
 (deftest builtin-json-unmarshal-test
-  (testing "json.unmarshal"
-    (is (= (builtin-json-unmarshal "{}") {}))
-    (is (= (builtin-json-unmarshal "null") nil))
-    (is (= (builtin-json-unmarshal "[1, 2, 3]") [1 2 3]))))
+  (testing-builtin "json.unmarshal"
+    ["{}"] {}
+    ["null"] nil
+    ["[1, 2, 3]"] [1 2 3]))
 
 (deftest builtin-json-is-valid-test
-  (testing "json.is_valid"
-    (is (= (builtin-json-is-valid "{}") true))
-    (is (= (builtin-json-is-valid "null") true))
-    (is (= (builtin-json-is-valid "[1, 2, 3]") true))
-    (is (= (builtin-json-is-valid "") false))
-    (is (= (builtin-json-is-valid "foo") false))
-    (is (= (builtin-json-is-valid "[[1, 2, 3]") false))))
+  (testing-builtin "json.is_valid"
+    ["{}"] true
+    ["null"] true
+    ["[1, 2, 3]"] true
+    [""] false
+    ["foo"] false
+    ["[[1, 2, 3]"] false))
 
 (deftest builtin-hex-encode-test
-  (testing "hex.encode"
-    (is (= (builtin-hex-encode "foobar") "666f6f626172"))
-    (is (= (builtin-hex-encode "🍺") "f09f8dba"))
-    (is (= (builtin-hex-encode "hex! hex!") "686578212068657821"))))
+  (testing-builtin "hex.encode"
+    ["foobar"] "666f6f626172"
+    ["🍺"] "f09f8dba"
+    ["hex! hex!"] "686578212068657821"))
 
 (deftest builtin-hex-decode-test
-  (testing "hex.decode"
-    (is (= (builtin-hex-decode "666f6f626172") "foobar"))
-    (is (= (builtin-hex-decode "f09f8dba") "🍺"))
-    (is (= (builtin-hex-decode "686578212068657821") "hex! hex!")))
-  (testing "invalid hex"
-    (is (thrown-with-msg? BuiltinException #"invalid byte: U\+0067 'g'" (builtin-hex-decode "fghijkl")))))
+  (testing-builtin "hex.decode"
+    ["666f6f626172"] "foobar"
+    ["f09f8dba"] "🍺"
+    ["686578212068657821"] "hex! hex!"
+    ; invalid hex
+    ["fghijkl"] [BuiltinException "invalid byte: U\\+0067 'g'"]))
 
 (deftest builtin-yaml-marshal-test
-  (testing "yaml.marshal"
-    (is (= (builtin-yaml-marshal {"foo" "bar"}) "foo: bar\n")))
-  (testing "sorted keys"
-    (is (= (builtin-yaml-marshal {"foo" "bar" "baz" {"x" 5}}) "baz:\n  x: 5\nfoo: bar\n"))))
+  (testing-builtin "yaml.marshal"
+    [{"foo" "bar"}] "foo: bar\n"
+    ; "sorted keys"
+    [{"foo" "bar" "baz" {"x" 5}}] "baz:\n  x: 5\nfoo: bar\n"))
 
 (deftest builtin-yaml-unmarshal-test
-  (testing "yaml.unmarshal"
-    (is (= (builtin-yaml-unmarshal "foo: bar") {"foo" "bar"})))
-  (testing "mimic error message from OPA"
-    (is (thrown-with-msg? BuiltinException
-                          #"eval_builtin_error: yaml.unmarshal: yaml: line 1: did not find expected ',' or ']'"
-                          (builtin-yaml-unmarshal "[1, 2")))))
+  (testing-builtin "yaml.unmarshal"
+    ["foo: bar"] {"foo" "bar"}
+    ; mimic error message from OPA
+    ["[1, 2"] [BuiltinException "yaml: line 1: did not find expected ',' or ']'"]))
 
 (deftest builtin-yaml-is-valid-test
-  (testing "yaml.is_valid"
-    (is (= (builtin-yaml-is-valid "foo: bar") true))
-    (is (= (builtin-yaml-is-valid "[[") false))))
+  (testing-builtin "yaml.is_valid"
+    ["foo: bar"] true
+    ["[["] false))

--- a/src/test/clojure/jarl/builtins/numbers_test.clj
+++ b/src/test/clojure/jarl/builtins/numbers_test.clj
@@ -1,86 +1,86 @@
 (ns jarl.builtins.numbers_test
-  (:require [clojure.test :refer [deftest is testing]]
-            [jarl.builtins.numbers :refer [builtin-plus builtin-minus builtin-mul builtin-div builtin-rem builtin-round
-                                           builtin-ceil builtin-floor builtin-abs builtin-numbers-range]])
-  (:import (se.fylling.jarl UndefinedException JarlException)))
+  (:require [clojure.test :refer [deftest is]]
+            [test.utils :refer [testing-builtin]]
+            [jarl.builtins.numbers :refer [builtin-rem]])
+  (:import (se.fylling.jarl JarlException BuiltinException)))
 
 (deftest builtin-plus-test
-  (testing "plus"
-    (is (= (builtin-plus 1 1) 2))
-    (is (= (builtin-plus 1.5 1.5) 3))
-    (is (= (builtin-plus 1.6 1.6) 3.2))
-    (is (= (builtin-plus -1.0 1) 0))))
+  (testing-builtin "plus"
+    [1 1] 2
+    [1.5 1.5] 3
+    [1.6 1.6] 3.2
+    [-1.0 1] 0))
 
 (deftest builtin-minus-test
-  (testing "minus"
-    (is (= (builtin-minus 1 1) 0))
-    (is (= (builtin-minus 1.5 2) -0.5))
-    (is (= (builtin-minus -1.5 -4.5) 3))
-    (is (= (builtin-minus -1.0 1) -2)))
-  (testing "set difference"
-    (is (= (builtin-minus #{1 2 3} #{2 3}) #{1}))
-    (is (= (builtin-minus #{1 2 3} #{4}) #{1 2 3}))
-    (is (= (builtin-minus #{1 2 3} #{}) #{1 2 3}))
-    (is (= (builtin-minus #{1 2 3} #{2 3 4}) #{1}))))
+  (testing-builtin "minus"
+    [1 1] 0
+    [1.5 2] -0.5
+    [-1.5 -4.5] 3
+    [-1.0 1] -2
+    ; set difference
+    [#{1 2 3} #{2 3}] #{1}
+    [#{1 2 3} #{4}] #{1 2 3}
+    [#{1 2 3} #{}] #{1 2 3}
+    [#{1 2 3} #{2 3 4}] #{1}))
 
 (deftest builtin-mul-test
-  (testing "mul"
-    (is (= (builtin-mul 1 1) 1))
-    (is (= (builtin-mul 1.5 2) 3))
-    (is (= (builtin-mul -1.5 -4.5) 6.75))
-    (is (= (builtin-mul -1.0 1) -1))))
+  (testing-builtin "mul"
+    [1 1] 1
+    [1.5 2] 3
+    [-1.5 -4.5] 6.75
+    [-1.0 1] -1))
 
 (deftest builtin-div-test
-  (testing "div"
-    (is (= (builtin-div 1 1) 1))
-    (is (= (builtin-div 1.0 1.0) 1))
-    (is (= (builtin-div 4 2) 2))
-    (is (= (builtin-div 1 3) 0.3333333333333333))
-    (is (= (builtin-div 1 2) 0.5)))
-  (testing "divide by zero"
-    (is (thrown-with-msg? UndefinedException #"div: divide by zero" (builtin-div 2 0)))))
+  (testing-builtin "div"
+    [1 1] 1
+    [1.0 1.0] 1
+    [4 2] 2
+    [1 3] 0.3333333333333333
+    [1 2] 0.5
+    ; divide by zero
+    [2 0] [BuiltinException "divide by zero"]))
 
 (deftest builtin-rem-test
-  (testing "rem"
-    (is (= (builtin-rem 5 2) 1))
-    (is (= (builtin-rem 2 2) 0))
-    (is (= (builtin-rem 2.0 2.0) 0)))
-  (testing "non-int result is undefined"
-    (is (thrown-with-msg? UndefinedException #"remainder is not an integer" (builtin-rem 2.0 1.5))))
-  (testing "rem by zero"
+  (testing-builtin "rem"
+    [5 2] 1
+    [2 2] 0
+    [2.0 2.0] 0
+    ; non-int result is undefined
+    [2.0 1.5] [BuiltinException "modulo on floating-point number"]
+    ; rem by zero
     (try
-      (builtin-rem 2 0)
+      (builtin-rem {:args [2 0]})
       (catch JarlException e
         (is (= (.getMessage e) "modulo by zero"))
         (is (= (.getType e) "eval_builtin_error"))))))
 
 (deftest builtin-round-test
-  (testing "round"
-    (is (= (builtin-round 1) 1))
-    (is (= (builtin-round 1.4) 1))
-    (is (= (builtin-round 1.5) 2))))
+  (testing-builtin "round"
+    [1] 1
+    [1.4] 1
+    [1.5] 2))
 
 (deftest builtin-ceil-test
-  (testing "ceil"
-    (is (= (builtin-ceil 1) 1))
-    (is (= (builtin-ceil 1.4) 2))
-    (is (= (builtin-ceil 1.01) 2))))
+  (testing-builtin "ceil"
+    [1] 1
+    [1.4] 2
+    [1.01] 2))
 
 (deftest builtin-floor-test
-  (testing "floor"
-    (is (= (builtin-floor 1) 1))
-    (is (= (builtin-floor 1.4) 1))
-    (is (= (builtin-floor 1.999) 1))))
+  (testing-builtin "floor"
+    [1] 1
+    [1.4] 1
+    [1.999] 1))
 
 (deftest builtin-abs-test
-  (testing "abs"
-    (is (= (builtin-abs 1) 1))
-    (is (= (builtin-abs -1) 1))
-    (is (= (builtin-abs -1.4) 1.4))))
+  (testing-builtin "abs"
+    [1] 1
+    [-1] 1
+    [-1.4] 1.4))
 
 (deftest builtin-numbers-range-test
-  (testing "numbers.range"
-    (is (= (builtin-numbers-range 1 5) [1 2 3 4 5]))
-    (is (= (builtin-numbers-range 1 1) [1]))
-    (is (= (builtin-numbers-range 5 1) [5 4 3 2 1]))
-    (is (= (builtin-numbers-range 49649733057 49649733060) [49649733057, 49649733058, 49649733059, 49649733060]))))
+  (testing-builtin "numbers.range"
+    [1 5] [1 2 3 4 5]
+    [1 1] [1]
+    [5 1] [5 4 3 2 1]
+    [49649733057 49649733060] [49649733057, 49649733058, 49649733059, 49649733060]))

--- a/src/test/clojure/jarl/builtins/objects_test.clj
+++ b/src/test/clojure/jarl/builtins/objects_test.clj
@@ -1,44 +1,43 @@
 (ns jarl.builtins.objects_test
-  (:require [clojure.test :refer [deftest is testing]]
-            [jarl.builtins.objects :refer [builtin-object-get builtin-object-remove builtin-object-union
-                                           builtin-object-union-n builtin-object-filter builtin-json-filter]]))
+  (:require [clojure.test :refer [deftest]]
+            [test.utils :refer [testing-builtin]]))
 
 (deftest builtin-object-get-test
-  (testing "object.get"
-    (is (= (builtin-object-get {"foo" "bar"} "foo" nil) "bar"))
-    (is (= (builtin-object-get {"foo" "bar"} "baz" nil) nil))
-    (is (= (builtin-object-get {"foo" "bar"} ["foo"] nil) "bar"))
-    (is (= (builtin-object-get {"foo" {"bar" [{"x" 1} {"y" 2}] }} ["foo" "bar" 1 "y"] nil) 2))))
+  (testing-builtin "object.get"
+    [{"foo" "bar"} "foo" nil] "bar"
+    [{"foo" "bar"} "baz" nil] nil
+    [{"foo" "bar"} ["foo"] nil] "bar"
+    [{"foo" {"bar" [{"x" 1} {"y" 2}] }} ["foo" "bar" 1 "y"] nil] 2))
 
 (deftest builtin-object-remove-test
-  (testing "object.remove"
-    (is (= (builtin-object-remove {"foo" "bar"} ["foo"]) {}))
-    (is (= (builtin-object-remove {"foo" "bar"} #{"foo"}) {}))
-    (is (= (builtin-object-remove {"a" 1 "b" 2 "c" {"d" 1 "e" 2}} {"c" {"d" 1}}) {"a" 1 "b" 2}))
-    (is (= (builtin-object-remove {"a" 1 "b" 2 "c" {"d" 1 "e" 2}} {"c" {"d" "ignored"}}) {"a" 1 "b" 2}))))
+  (testing-builtin "object.remove"
+    [{"foo" "bar"} ["foo"]] {}
+    [{"foo" "bar"} #{"foo"}] {}
+    [{"a" 1 "b" 2 "c" {"d" 1 "e" 2}} {"c" {"d" 1}}] {"a" 1 "b" 2}
+    [{"a" 1 "b" 2 "c" {"d" 1 "e" 2}} {"c" {"d" "ignored"}}] {"a" 1 "b" 2}))
 
 (deftest builtin-object-union-test
-  (testing "object.union"
-    (is (= (builtin-object-union {"foo" "bar"} {"foo" "baz"}) {"foo" "baz"}))
-    (is (= (builtin-object-union {"foo" "bar"} {"foo" "bar" "x" 1}) {"foo" "bar" "x" 1}))))
+  (testing-builtin "object.union"
+    [{"foo" "bar"} {"foo" "baz"}] {"foo" "baz"}
+    [{"foo" "bar"} {"foo" "bar" "x" 1}] {"foo" "bar" "x" 1}))
 
 (deftest builtin-object-union-n-test
-  (testing "object.union_n"
-    (is (= (builtin-object-union-n [{"foo" "bar"} {"foo" "baz"}]) {"foo" "baz"}))
-    (is (= (builtin-object-union-n [{"foo" "bar"} {"foo" "bar" "x" 1}]) {"foo" "bar" "x" 1}))
-    (is (= (builtin-object-union-n [{"foo" "bar"} {"foo" "baz"} {"x" 1} {"y" 2 "x" 10}]) {"foo" "baz" "x" 10 "y" 2}))))
+  (testing-builtin "object.union_n"
+    [[{"foo" "bar"} {"foo" "baz"}]] {"foo" "baz"}
+    [[{"foo" "bar"} {"foo" "bar" "x" 1}]] {"foo" "bar" "x" 1}
+    [[{"foo" "bar"} {"foo" "baz"} {"x" 1} {"y" 2 "x" 10}]] {"foo" "baz" "x" 10 "y" 2}))
 
 (deftest builtin-object-filter-test
-  (testing "object.filter"
-    (is (= (builtin-object-filter {"a" 1 "b" 2 "c" 3} ["b" "c"]) {"b" 2 "c" 3}))
-    (is (= (builtin-object-filter {"a" 1 "b" 2 "c" 3} {"b" 2}) {"b" 2}))
-    (is (= (builtin-object-filter {"a" 1 "b" 2 "c" 3} {}) {}))))
+  (testing-builtin "object.filter"
+    [{"a" 1 "b" 2 "c" 3} ["b" "c"]] {"b" 2 "c" 3}
+    [{"a" 1 "b" 2 "c" 3} {"b" 2}] {"b" 2}
+    [{"a" 1 "b" 2 "c" 3} {}] {}))
 
-(deftest builtin-json-filter-test
-  (testing "json.filter"
-    (is (= (builtin-json-filter {"a" 1 "b" 2 "c" {"foo" "bar" "x" 10}} ["b" "c/foo"]) {"b" 2 "c" {"foo" "bar"}})))
+;(deftest builtin-json-filter-test
+;  (testing-builtin "json.filter"
+;    [{"a" 1 "b" 2 "c" {"foo" "bar" "x" 10}} ["b" "c/foo"]] {"b" 2 "c" {"foo" "bar"}}
   ;(testing "nested arrays"
   ;  (is (= (builtin-json-filter {"a" 1 "b" 2 "c" {"d" 1 "e" [1 {"foo" "bar"}]}} ["a", "c/d", "c/e/1/foo"])
   ;         {"a" 1 "c" {"d" 1
   ;                     "e" [{"foo" "bar"}]}})))
-  )
+  ;))

--- a/src/test/clojure/jarl/builtins/regex_test.clj
+++ b/src/test/clojure/jarl/builtins/regex_test.clj
@@ -1,26 +1,25 @@
 (ns jarl.builtins.regex_test
-  (:require [clojure.test :refer [deftest is testing]]
-            [jarl.builtins.regex :refer [builtin-regex-match builtin-regex-is-valid builtin-regex-split
-                                         builtin-regex-find-n]]))
+  (:require [clojure.test :refer [deftest]]
+            [test.utils :refer [testing-builtin]]))
 
 (deftest builtin-regex-match-test
-  (testing "regex.match"
-    (is (= (builtin-regex-match "[\\d]+" "123") true))))
+  (testing-builtin "regex.match"
+    ["[\\d]+" "123"] true))
 
 (deftest builtin-regex-is-valid-test
-  (testing "regex.is_valid"
-    (is (= (builtin-regex-is-valid "[\\d]+") true))
-    (is (= (builtin-regex-is-valid "+++") false))
-    (is (= (builtin-regex-is-valid 5) false))))
+  (testing-builtin "regex.is_valid"
+    ["[\\d]+"] true
+    ["+++"] false
+    [5] false))
 
 (deftest builtin-regex-split-test
-  (testing "regex.split"
-    (is (= (builtin-regex-split "[\\d]" "a1b2c") ["a" "b" "c"]))))
+  (testing-builtin "regex.split"
+    ["[\\d]" "a1b2c"] ["a" "b" "c"]))
 
 (deftest builtin-regex-find-n-test
-  (testing "regex.find_n"
-    (is (= (builtin-regex-find-n "[\\d]" "a1b2c3" 0) []))
-    (is (= (builtin-regex-find-n "[\\d]" "a1b2c3" 3) ["1" "2" "3"]))
-    (is (= (builtin-regex-find-n "[\\d]" "a1b2c3" -1) ["1" "2" "3"]))
-    (is (= (builtin-regex-find-n "[\\d]" "a1b2c3" 2) ["1" "2"]))
-    (is (= (builtin-regex-find-n "[biw]" "bird is the word" 10) ["b" "i" "i" "w"]))))
+  (testing-builtin "regex.find_n"
+    ["[\\d]" "a1b2c3" 0] []
+    ["[\\d]" "a1b2c3" 3] ["1" "2" "3"]
+    ["[\\d]" "a1b2c3" -1] ["1" "2" "3"]
+    ["[\\d]" "a1b2c3" 2] ["1" "2"]
+    ["[biw]" "bird is the word" 10] ["b" "i" "i" "w"]))

--- a/src/test/clojure/jarl/builtins/sets_test.clj
+++ b/src/test/clojure/jarl/builtins/sets_test.clj
@@ -1,25 +1,25 @@
 (ns jarl.builtins.sets_test
-  (:require [clojure.test :refer [deftest is testing]]
-            [jarl.builtins.sets :refer [builtin-and builtin-or builtin-intersection builtin-union]]))
+  (:require [clojure.test :refer [deftest]]
+            [test.utils :refer [testing-builtin]]))
 
 (deftest builtin-and-test
-  (testing "and" ; intersection
-    (is (= (builtin-and #{4 9 1} #{1 5 4}) #{1 4}))
-    (is (= (builtin-and #{1} #{2}) #{}))))
+  (testing-builtin "and" ; intersection
+    [#{4 9 1} #{1 5 4}] #{1 4}
+    [#{1} #{2}] #{}))
 
 (deftest builtin-or-test
-  (testing "or" ; union
-    (is (= (builtin-or #{4 9 1} #{1 5 4}) #{1 4 5 9}))))
+  (testing-builtin "or" ; union
+    [#{4 9 1} #{1 5 4}] #{1 4 5 9}))
 
 (deftest builtin-intersection-test
-  (testing "intersection"
-    (is (= (builtin-intersection #{}) #{}))
-    (is (= (builtin-intersection #{#{1 5 4} #{1 2 3} #{7 1 4}}) #{1}))
-    (is (= (builtin-intersection #{#{1 5 4} #{1 2 3 4} #{7 1 4}}) #{1 4}))
-    (is (= (builtin-intersection #{#{1 5 4} #{2 3} #{7 5}}) #{}))))
+  (testing-builtin "intersection"
+    [#{}] #{}
+    [#{#{1 5 4} #{1 2 3} #{7 1 4}}] #{1}
+    [#{#{1 5 4} #{1 2 3 4} #{7 1 4}}] #{1 4}
+    [#{#{1 5 4} #{2 3} #{7 5}}] #{}))
 
 (deftest builtin-union-test
-  (testing "union"
-    (is (= (builtin-union #{#{1 5 4} #{1 2 3} #{7 1 4 6}}) #{1 2 3 4 5 6 7}))
-    (is (= (builtin-union #{#{1 5 4} #{1 2 3 4} #{7 1 4}}) #{1 2 3 4 5 7}))
-    (is (= (builtin-union #{#{1} #{}}) #{1}))))
+  (testing-builtin "union"
+    [#{#{1 5 4} #{1 2 3} #{7 1 4 6}}] #{1 2 3 4 5 6 7}
+    [#{#{1 5 4} #{1 2 3 4} #{7 1 4}}] #{1 2 3 4 5 7}
+    [#{#{1} #{}}] #{1}))

--- a/src/test/clojure/jarl/builtins/strings_test.clj
+++ b/src/test/clojure/jarl/builtins/strings_test.clj
@@ -1,149 +1,145 @@
 (ns jarl.builtins.strings_test
-  (:require [clojure.test :refer [deftest is testing]]
-            [jarl.builtins.strings :refer [builtin-concat builtin-contains builtin-endswith builtin-format-int
-                                           builtin-indexof builtin-indexof-n builtin-lower builtin-replace
-                                           builtin-strings-reverse builtin-split builtin-startswith builtin-substring
-                                           builtin-trim builtin-trim-left builtin-trim-prefix builtin-trim-right
-                                           builtin-trim-suffix builtin-trim-space builtin-upper]])
+  (:require [clojure.test :refer [deftest]]
+            [test.utils :refer [testing-builtin]])
   (:import (se.fylling.jarl BuiltinException)))
 
 (deftest builtin-concat-test
-  (testing "concat"
-    (is (= (builtin-concat ", " ["a" "b" "c"]) "a, b, c"))
-    (is (= (builtin-concat "🙂" ["🙃" "🙃" "🙃"]) "🙃🙂🙃🙂🙃")))
-  (testing "concat sets"
-    (is (= (builtin-concat ", " #{"a", "b", "c"}) "a, b, c"))
-    (is (= (builtin-concat ", " #{"c", "b", "a"}) "a, b, c"))))
+  (testing-builtin "concat"
+    [", " ["a" "b" "c"]] "a, b, c"
+    ["🙂" ["🙃" "🙃" "🙃"]] "🙃🙂🙃🙂🙃"
+    ; concat sets
+    [", " #{"a", "b", "c"}] "a, b, c"
+    [", " #{"c", "b", "a"}] "a, b, c"))
 
 (deftest builtin-contains-test
-  (testing "contains"
-    (is (= (builtin-contains "some text included" "text") true))
-    (is (= (builtin-contains "some ünicÖde works" "ünicÖde") true))
-    (is (= (builtin-contains "negative test" "positive") false))
-    (is (= (builtin-contains "🍧🍨🧁🍰🍮" "🍨🧁🍰") true))))
+  (testing-builtin "contains"
+    ["some text included" "text"] true
+    ["some ünicÖde works" "ünicÖde"] true
+    ["negative test" "positive"] false
+    ["🍧🍨🧁🍰🍮" "🍨🧁🍰"] true))
 
 (deftest builtin-endswith-test
-  (testing "endswith"
-    (is (= (builtin-endswith "some text included" "included") true))
-    (is (= (builtin-endswith "some ünicÖde" "ünicÖde") true))
-    (is (= (builtin-endswith "negative test" "positive") false))))
+  (testing-builtin "endswith"
+    ["some text included" "included"] true
+    ["some ünicÖde" "ünicÖde"] true
+    ["negative test" "positive"] false))
 
 (deftest builtin-format-int-test
-  (testing "format_int"
-    (is (= (builtin-format-int 10 10) "10"))
-    (is (= (builtin-format-int 10 2) "1010"))
-    (is (= (builtin-format-int 10 16) "a"))))
+  (testing-builtin "format_int"
+    [10 10] "10"
+    [10 2] "1010"
+    [10 16] "a"))
 
 (deftest builtin-indexof-test
-  (testing "indexof"
-    (is (= (builtin-indexof "some text included" "text") 5))
-    (is (= (builtin-indexof "some ünicÖde" "ünicÖde") 5))
-    (is (= (builtin-indexof "negative test" "positive") -1))
-    (is (= (builtin-indexof "🍧🍨🧁🍰🍮" "🍮") 4))))
+  (testing-builtin "indexof"
+    ["some text included" "text"] 5
+    ["some ünicÖde" "ünicÖde"] 5
+    ["negative test" "positive"] -1
+    ["🍧🍨🧁🍰🍮" "🍮"] 4))
 
 (deftest builtin-indexof-n-test
-  (testing "indexof_n"
-    (is (= (builtin-indexof-n "some text included" "e") [3 6 16]))
-    (is (= (builtin-indexof-n "some ünicÖde" "Ö") [9]))
-    (is (= (builtin-indexof-n "negative test" "positive") []))
-    (is (= (builtin-indexof-n "🍧🍮🍨🧁🍰🍮" "🍮") [1 5]))))
+  (testing-builtin "indexof_n"
+    ["some text included" "e"] [3 6 16]
+    ["some ünicÖde" "Ö"] [9]
+    ["negative test" "positive"] []
+    ["🍧🍮🍨🧁🍰🍮" "🍮"] [1 5]))
 
 (deftest builtin-lower-test
-  (testing "lower"
-    (is (= (builtin-lower "ABBA") "abba"))
-    (is (= (builtin-lower "ÛnicÖde") "ûnicöde"))))
+  (testing-builtin "lower"
+    ["ABBA"] "abba"
+    ["ÛnicÖde"] "ûnicöde"))
 
 (deftest builtin-replace-test
-  (testing "replace"
-    (is (= (builtin-replace "abba" "a" "e") "ebbe"))
-    (is (= (builtin-replace "abba" "e" "a") "abba"))
-    (is (= (builtin-replace "ÛnicÖde" "Ö" "o") "Ûnicode"))))
+  (testing-builtin "replace"
+    ["abba" "a" "e"] "ebbe"
+    ["abba" "e" "a"] "abba"
+    ["ÛnicÖde" "Ö" "o"] "Ûnicode"))
 
 (deftest builtin-strings-reverse-test
-  (testing "strings.reverse"
-    (is (= (builtin-strings-reverse "abba") "abba"))
-    (is (= (builtin-strings-reverse "ÛnicÖde") "edÖcinÛ"))))
+  (testing-builtin "strings.reverse"
+    ["abba"] "abba"
+    ["ÛnicÖde"] "edÖcinÛ"))
 
 (deftest builtin-split-test
-  (testing "split"
-    (is (= (builtin-split "a,b,c" ",") ["a" "b" "c"]))
-    (is (= (builtin-split "abc", ",") ["abc"]))
-    (is (= (builtin-split "abc" "") ["a" "b" "c"]))
-    (is (= (builtin-split "abc" "a") ["" "bc"]))
-    (is (= (builtin-split "åäö" "") ["å" "ä" "ö"]))
-    (is (= (builtin-split ",a,b,,c", ",") ["", "a", "b", "", "c"])))
-  (testing "regex escape"
-    (is (= (builtin-split "a[b[c" "[") ["a" "b" "c"]))
-    (is (= (builtin-split "a*b*c" "*") ["a" "b" "c"])))
-  (testing "string and delim are the same (quirk)"
-    (is (= (builtin-split "abc", "abc") ["" ""]))))
+  (testing-builtin "split"
+    ["a,b,c" ","] ["a" "b" "c"]
+    ["abc", ","] ["abc"]
+    ["abc" ""] ["a" "b" "c"]
+    ["abc" "a"] ["" "bc"]
+    ["åäö" ""] ["å" "ä" "ö"]
+    [",a,b,,c", ","] ["", "a", "b", "", "c"]
+    ; regex escape
+    ["a[b[c" "["] ["a" "b" "c"]
+    ["a*b*c" "*"] ["a" "b" "c"]
+    ; string and delim are the same (quirk)
+    ["abc", "abc"] ["" ""]))
 
 (deftest builtin-startswith-test
-  (testing "startswith"
-    (is (= (builtin-startswith "some text included" "some") true))
-    (is (= (builtin-startswith "ünicÖde everywhere" "ünicÖde") true))
-    (is (= (builtin-startswith "negative test" "positive") false))))
+  (testing-builtin "startswith"
+    ["some text included" "some"] true
+    ["ünicÖde everywhere" "ünicÖde"] true
+    ["negative test" "positive"] false))
 
 (deftest builtin-substring-test
-  (testing "substring"
-    (is (= (builtin-substring "abcde" 1 3) "bcd"))
-    (is (= (builtin-substring "aaa" 4 -1) ""))
-    (is (= (builtin-substring "aaa" 3 3) ""))
-    (is (= (builtin-substring "abcde" 0 5) "abcde"))
-    (is (= (builtin-substring "ünicÖde" 4 1) "Ö"))
-    (is (= (builtin-substring "a" 0 100) "a"))
-    (is (= (builtin-substring "everything" 0 -1) "everything")))
-  (testing "code points"
-    (is (= (builtin-substring "⭐🚀🙂" 0 1) "⭐"))
-    (is (= (builtin-substring "⭐🚀🙂" 1 1) "🚀"))
-    (is (= (builtin-substring "⭐🚀🙂" 0 -1) "⭐🚀🙂"))
-    (is (= (builtin-substring "⭐🚀🙂" 1 -1) "🚀🙂"))
-    (is (= (builtin-substring "𨦇𨦈𥻘" 1 2) "𨦈𥻘")))
-  (testing "negative offset"
-    (is (thrown-with-msg? BuiltinException #"negative offset" (builtin-substring "a" -1 1)))))
+  (testing-builtin "substring"
+    ["abcde" 1 3] "bcd"
+    ["aaa" 4 -1] ""
+    ["aaa" 3 3] ""
+    ["abcde" 0 5] "abcde"
+    ["ünicÖde" 4 1] "Ö"
+    ["a" 0 100] "a"
+    ["everything" 0 -1] "everything"
+    ; code points
+    ["⭐🚀🙂" 0 1] "⭐"
+    ["⭐🚀🙂" 1 1] "🚀"
+    ["⭐🚀🙂" 0 -1] "⭐🚀🙂"
+    ["⭐🚀🙂" 1 -1] "🚀🙂"
+    ["𨦇𨦈𥻘" 1 2] "𨦈𥻘"
+    ; negative offset
+    ["a" -1 1] [BuiltinException "negative offset"]))
 
 (deftest builtin-trim-test
-  (testing "trim"
-    (is (= (builtin-trim "abcde" "ae") "bcd"))
-    (is (= (builtin-trim "abcde" "cbae") "d"))
-    (is (= (builtin-trim "aalalaah" "ah") "lal"))
-    (is (= (builtin-trim "   test " " t") "es"))
-    (is (= (builtin-trim "foo" "foo") ""))))
+  (testing-builtin "trim"
+    ["abcde" "ae"] "bcd"
+    ["abcde" "cbae"] "d"
+    ["aalalaah" "ah"] "lal"
+    ["   test " " t"] "es"
+    ["foo" "foo"] ""))
 
 (deftest builtin-trim-left-test
-  (testing "trim_left"
-    (is (= (builtin-trim-left "abcde" "x") "abcde"))
-    (is (= (builtin-trim-left "abcde" "cba") "de"))
-    (is (= (builtin-trim-left "åäö" "åä") "ö"))
-    (is (= (builtin-trim-left "   test" " t") "est"))
-    (is (= (builtin-trim-left "foo" "foo") ""))))
+  (testing-builtin "trim_left"
+    ["abcde" "x"] "abcde"
+    ["abcde" "cba"] "de"
+    ["åäö" "åä"] "ö"
+    ["   test" " t"] "est"
+    ["foo" "foo"] ""))
 
 (deftest builtin-trim-prefix-test
-  (testing "trim_prefix"
-    (is (= (builtin-trim-prefix "some text included" "some ") "text included"))
-    (is (= (builtin-trim-prefix "ünicÖde everywhere" "ünicÖde ") "everywhere"))
-    (is (= (builtin-trim-prefix "negative test" "positive") "negative test"))))
+  (testing-builtin "trim_prefix"
+    ["some text included" "some "] "text included"
+    ["ünicÖde everywhere" "ünicÖde "] "everywhere"
+    ["negative test" "positive"] "negative test"))
 
 (deftest builtin-trim-right-test
-  (testing "trim_right"
-    (is (= (builtin-trim-right "abcde" "x") "abcde"))
-    (is (= (builtin-trim-right "abcde" "cde") "ab"))
-    (is (= (builtin-trim-right "åäö" "öä") "å"))
-    (is (= (builtin-trim-right "test   " " t") "tes"))))
+  (testing-builtin "trim_right"
+    ["abcde" "x"] "abcde"
+    ["abcde" "cde"] "ab"
+    ["åäö" "öä"] "å"
+    ["test   " " t"] "tes"))
 
 (deftest builtin-trim-suffix-test
-  (testing "trim_suffix"
-    (is (= (builtin-trim-suffix "some text included" " included") "some text"))
-    (is (= (builtin-trim-suffix "ünicÖde everywhere" " everywhere") "ünicÖde"))
-    (is (= (builtin-trim-suffix "negative test" "positive") "negative test"))))
+  (testing-builtin "trim_suffix"
+    ["some text included" " included"] "some text"
+    ["ünicÖde everywhere" " everywhere"] "ünicÖde"
+    ["negative test" "positive"] "negative test"))
 
 (deftest builtin-trim-space-test
-  (testing "upper"
-    (is (= (builtin-trim-space "  foo  ") "foo"))
-    (is (= (builtin-trim-space "foo") "foo"))
-    (is (= (builtin-trim-space "\n\t foo\n \n") "foo"))))
+  (testing-builtin "trim_space"
+    ["  foo  "] "foo"
+    ["foo"] "foo"
+    ["\n\t foo\n \n"] "foo"))
 
 (deftest builtin-upper-test
-  (testing "upper"
-    (is (= (builtin-upper "abba") "ABBA"))
-    (is (= (builtin-upper "ûnicöde") "ÛNICÖDE"))))
+  (testing-builtin "upper"
+    ["abba"] "ABBA"
+    ["ûnicöde"] "ÛNICÖDE"))

--- a/src/test/clojure/jarl/builtins/types_test.clj
+++ b/src/test/clojure/jarl/builtins/types_test.clj
@@ -1,67 +1,62 @@
 (ns jarl.builtins.types_test
-  (:require [clojure.test :refer [deftest is testing]]
-            [jarl.builtins.types :refer [builtin-is-number builtin-is-string builtin-is-boolean builtin-is-array
-                                         builtin-is-set builtin-is-object builtin-is-null builtin-type-name]])
-  (:import (se.fylling.jarl UndefinedException)
-           (java.util.regex Pattern)))
+  (:require [clojure.test :refer [deftest]]
+            [test.utils :refer [testing-builtin]])
+  (:import (se.fylling.jarl UndefinedException)))
 
 (deftest builtin-is-number-test
-  (testing "is_number"
-    (is (= (builtin-is-number 1) true))
-    (is (= (builtin-is-number 1.3) true))
-  (testing "not a number"
-    (is (thrown-with-msg? UndefinedException #"foo is not a number" (builtin-is-number "foo"))))))
+  (testing-builtin "is_number"
+    [1] true
+    [1.3] true
+    ; not a number
+    ["foo"] [UndefinedException "foo is not a number"]))
 
 (deftest builtin-is-string-test
-  (testing "is_string"
-    (is (= (builtin-is-string "") true))
-    (is (= (builtin-is-string "foo") true))
-    (testing "not a string"
-      (is (thrown-with-msg? UndefinedException #"22 is not a string" (builtin-is-string 22))))))
+  (testing-builtin "is_string"
+    [""] true
+    ["foo"] true
+    ; not a string
+    [22] [UndefinedException "22 is not a string"]))
 
 (deftest builtin-is-boolean-test
-  (testing "is_boolean"
-    (is (= (builtin-is-boolean true) true))
-    (is (= (builtin-is-boolean false) true))
-    (testing "not a boolean"
-      (is (thrown-with-msg? UndefinedException #"foo is not a boolean" (builtin-is-boolean "foo"))))))
+  (testing-builtin "is_boolean"
+    [true] true
+    [false] true
+    ; not a boolean
+    ["foo"] [UndefinedException "foo is not a boolean"]))
 
 (deftest builtin-is-array-test
-  (testing "is_array"
-    (is (= (builtin-is-array []) true))
-    (is (= (builtin-is-array [1 "foo"]) true))
-    (testing "not an array"
-      (is (thrown-with-msg? UndefinedException #"foo is not an array" (builtin-is-array "foo"))))))
+  (testing-builtin "is_array"
+    [[]] true
+    [[1 "foo"]] true
+    ; not an array
+    ["foo"] [UndefinedException "foo is not an array"]))
 
 (deftest builtin-is-set-test
-  (testing "is_set"
-    (is (= (builtin-is-set #{}) true))
-    (is (= (builtin-is-set #{1 2 3}) true))
-    (testing "not a set"
-      (is (thrown-with-msg? UndefinedException
-                            (re-pattern (Pattern/quote "[1 2 3] is not a set")) (builtin-is-set [1 2 3]))))))
+  (testing-builtin "is_set"
+    [#{}] true
+    [#{1 2 3}] true
+    ; not a set
+    [[1 2 3]] [UndefinedException "\\[1 2 3\\] is not a set"]))
 
 (deftest builtin-is-object-test
-  (testing "is_object"
-    (is (= (builtin-is-object {}) true))
-    (is (= (builtin-is-object {"a" 1 "b" 2}) true))
-    (testing "not an object"
-      (is (thrown-with-msg? UndefinedException
-                            (re-pattern (Pattern/quote "[1 2 3] is not an object")) (builtin-is-object [1 2 3]))))))
+  (testing-builtin "is_object"
+    [{}] true
+    [{"a" 1 "b" 2}] true
+    ; not an object
+    [[1 2 3]] [UndefinedException "\\[1 2 3\\] is not an object"]))
 
 (deftest builtin-is-null-test
-  (testing "is_null"
-    (is (= (builtin-is-null nil) true))
-    (testing "not nil"
-      (is (thrown-with-msg? UndefinedException
-                            (re-pattern (Pattern/quote "[1 2 3] is not null")) (builtin-is-null [1 2 3]))))))
+  (testing-builtin "is_null"
+    [nil] true
+    ; not nil
+    [[1 2 3]] [UndefinedException "\\[1 2 3\\] is not null"]))
 
 (deftest builtin-type-name-test
-  (testing "type_name"
-    (is (= (builtin-type-name "foo") "string"))
-    (is (= (builtin-type-name 1) "number"))
-    (is (= (builtin-type-name 3.14) "number"))
-    (is (= (builtin-type-name true) "boolean"))
-    (is (= (builtin-type-name nil) "null"))
-    (is (= (builtin-type-name {"foo" "bar"}) "object"))
-    (is (= (builtin-type-name #{1 2}) "set"))))
+  (testing-builtin "type_name"
+    ["foo"] "string"
+    [1] "number"
+    [3.14] "number"
+    [true] "boolean"
+    [nil] "null"
+    [{"foo" "bar"}] "object"
+    [#{1 2}] "set"))

--- a/src/test/clojure/jarl/builtins/utils_test.clj
+++ b/src/test/clojure/jarl/builtins/utils_test.clj
@@ -2,24 +2,24 @@
   (:require [clojure.test :refer [deftest is testing]]
             [jarl.exceptions :as errors]
             [jarl.builtins.utils :refer [typed-seq]])
-  (:import (se.fylling.jarl BuiltinException)))
+  (:import (se.fylling.jarl BuiltinException TypeException)))
 
 (deftest builtin-ex-test
   (testing "formatting"
     (let [ex (errors/builtin-ex "my message #%d caused by %s" 1 "incompetence")]
       (is (instance? BuiltinException ex))
-      (is (= (.getMessage ^Throwable ex) "my message #1 caused by incompetence"))))
+      (is (= (.getMessage ^Throwable ex) "eval_builtin_error: my message #1 caused by incompetence"))))
   (testing "no formatting"
     (let [ex (errors/builtin-ex "my message caused by insomnia")]
       (is (instance? BuiltinException ex))
-      (is (= (.getMessage ^Throwable ex) "my message caused by insomnia")))))
+      (is (= (.getMessage ^Throwable ex) "eval_builtin_error: my message caused by insomnia")))))
 
 (deftest typed-seq-test
   (testing "typed-seq compliant"
-    (is (nil? (typed-seq ["1", 2, "foo"] #{"string" "number"})))
-    (is (nil? (typed-seq #{[1, 2], {"foo" "bar"}} ["array" "object"]))))
+    (is (nil? (typed-seq "foo" ["1", 2, "foo"] #{"string" "number"})))
+    (is (nil? (typed-seq "bar" #{[1, 2], {"foo" "bar"}} ["array" "object"]))))
   (testing "typed-seq violations"
-    (is (thrown-with-msg? BuiltinException #"operand must be array or set of string but got array or set containing number"
-                          (typed-seq [1] #{"string"})))
-    (is (thrown-with-msg? BuiltinException #"operand must be array or set of string but got array or set containing number"
-                          (typed-seq ["foo" 1] #{"string"})))))
+    (is (thrown-with-msg? TypeException #"operand must be array or set of string but got array or set containing number"
+                          (typed-seq "foo" [1] #{"string"})))
+    (is (thrown-with-msg? TypeException #"operand must be array or set of string but got array or set containing number"
+                          (typed-seq "foo "["foo" 1] #{"string"})))))

--- a/src/test/clojure/jarl/exceptions_test.clj
+++ b/src/test/clojure/jarl/exceptions_test.clj
@@ -1,0 +1,21 @@
+(ns jarl.exceptions-test
+  (:require [clojure.test :refer [deftest testing is]]
+            [jarl.exceptions :refer [resolve-jarl-exception throws? try-or]])
+  (:import (se.fylling.jarl BuiltinException UndefinedException)))
+
+(deftest resolve-jarl-exception-test
+  (testing "resolve-jarl-exception"
+    (is (= (resolve-jarl-exception BuiltinException) BuiltinException))
+    (is (= (resolve-jarl-exception 'BuiltinException) BuiltinException))
+    (is (= (resolve-jarl-exception 'UndefinedException) UndefinedException))
+    (is (nil? (resolve-jarl-exception RuntimeException)))))
+
+(deftest throws?-test
+  (testing "throws?"
+    (is (= (throws? #(Integer/parseInt "100")) false))
+    (is (= (throws? #(Integer/parseInt "foo")) true))))
+
+(deftest try-or-test
+  (testing "try-or"
+    (is (= (try-or (Integer/parseInt "foo") 1) 1))
+    (is (= (try-or (Integer/parseInt "2")   1) 2))))

--- a/src/test/clojure/jarl/state_test.clj
+++ b/src/test/clojure/jarl/state_test.clj
@@ -1,23 +1,6 @@
-;
-; Copyright 2022 Johan Fylling, Anders Eknert
-;
-; Licensed under the Apache License, Version 2.0 (the "License")
-; you may not use this file except in compliance with the License.
-; You may obtain a copy of the License at
-;
-;     http://www.apache.org/licenses/LICENSE-2.0
-;
-; Unless required by applicable law or agreed to in writing, software
-; distributed under the License is distributed on an "AS IS" BASIS,
-; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-; See the License for the specific language governing permissions and
-; limitations under the License.
-;
-
 (ns jarl.state_test
   (:require [clojure.test :refer [deftest is testing]]
             [jarl.state :refer [get-local push-with-stack]]))
-
 
 (deftest get-local-test
   (testing "empty state"

--- a/src/test/clojure/test/utils.clj
+++ b/src/test/clojure/test/utils.clj
@@ -1,4 +1,8 @@
-(ns test.utils)
+(ns test.utils
+  (:require [clojure.test :refer [is]]
+            [clojure.string :as str]
+            [jarl.exceptions :as errors]
+            [jarl.builtins.registry :as registry]))
 
 ; inspired by https://gist.github.com/joelittlejohn/2ecc1256e5d184d78f30fd6c4641099e
 
@@ -6,3 +10,47 @@
   "Add a test to the given namespace."
   [name ns test-fn & [metadata]]
   (intern ns (with-meta (symbol name) (merge metadata {:test #(test-fn)})) (fn [])))
+
+(defmacro testing-builtin
+  "Given the name of a builtin (as named in OPA, e.g. 'base64.encode'),
+  and a series of inputs to use when calling the function, and the output
+  to expect, i.e.:
+
+  (testing-builtin \"count\"
+    ; args-list    expected
+    [#{1 2 3}]     3
+    [(range 5)]    5)
+
+  Expands to:
+
+  (testing \"count\"
+    (is (= (builtin-count {:args [#{1 2 3}]}) 3)
+    (is (= (builtin-count {:args [(range 5)]}) 5))
+
+  Expected exception may be tried using a vector with first element as the exception type, and the second element
+  a string that will be compiled to a regex for a match on the error message:
+
+  (testing \"sum\"
+    [2 0] [BuiltinException \"divide by zero\"]))"
+  [name & forms]
+  (let [func (registry/get-builtin name)
+        func-name (str "builtin-" (str/replace name #"[\._]" "-"))
+        pairs (partition 2 forms)
+        stmts (map (fn [[args expect]]
+                     (if (vector? expect)
+                       (if-let [expect-ex (errors/resolve-jarl-exception (first expect))]
+                         (let [ex-type (errors/rego-ex-type-from-class expect-ex)
+                               ex-type-str (if (= ex-type "") "" (str ex-type ": "))
+                               expect-pattern (re-pattern (str ex-type-str name ": " (second expect)))
+                               provided-ex (try (func {:args args}) (catch Exception e e))]
+                           `(do
+                              (is (= ~(type provided-ex) ~expect-ex))
+                              (is (re-find ~expect-pattern ~(ex-message provided-ex))
+                                  ~(str "Expected match for pattern '" expect-pattern "' but '" (ex-message provided-ex) "' does not match"))))
+                         ; else - not exception
+                         `(is (= (~func {:args ~args}) ~expect)))
+                       ; else - not vector
+                       `(is (= (~func {:args ~args}) ~expect))))
+                   pairs)]
+    `(clojure.test/testing ~func-name
+       ~@stmts)))

--- a/src/test/clojure/test/utils_test.clj
+++ b/src/test/clojure/test/utils_test.clj
@@ -1,0 +1,11 @@
+(ns test.utils-test
+  (:require [clojure.test :refer [deftest testing is]]
+            [test.utils :refer [testing-builtin]]
+            [jarl.builtins.aggregates])
+  (:import (se.fylling.jarl TypeException)))
+
+(deftest testing-builtin-test
+  (testing "simple args expansion"
+    (is (testing-builtin "count" [#{1}] 1) true))
+  (testing "exceptions"
+    (is (testing-builtin "sum" [[5 "5"]] [TypeException "operand"]))))


### PR DESCRIPTION
Also:
* Refactor unit tests to use testing-builtin macro
* Add to_number and cast_* builtin functions
* Fix linter warnings and suggestions

Signed-off-by: Anders Eknert <anders@eknert.com>