### PR TITLE
Allow builtins resolver to be provided

### DIFF
--- a/src/main/clojure/jarl/utils.clj
+++ b/src/main/clojure/jarl/utils.clj
@@ -5,10 +5,6 @@
            (java.util Base64)
            (java.net URLDecoder URLEncoder)))
 
-; FIXME: drop "undefined" values? (new 'Undefined' type required)
-(defn map-by-index [array]
-  (zipmap (range (count array)) array))
-
 (defn base64-encode [^String s]
   (.encodeToString (Base64/getEncoder) (.getBytes s StandardCharsets/UTF_8)))
 

--- a/src/test/clojure/jarl/compliance_test.clj
+++ b/src/test/clojure/jarl/compliance_test.clj
@@ -37,6 +37,12 @@
     "{\"foo\": {{1}}}" {"foo" #{#{1}}}
     (json/read-str term)))
 
+(def test-builtins
+  {"opa.runtime" (fn [_] {})})
+
+(defn compliance-builtin-resolver [builtin-name]
+  (get test-builtins builtin-name (registry/get-builtin builtin-name)))
+
 (defn- do-test [{:strs           [data note]
                  entry-points    "entrypoints"
                  want-results    "want_plan_result"
@@ -48,7 +54,7 @@
   (let [input (if (contains? test-case "input_term")
                 (parse-input-term (get test-case "input_term"))
                 (get test-case "input"))
-        info (cond-> (parse ir)
+        info (cond-> (parse ir compliance-builtin-resolver)
                      (true? (get test-case "strict_error")) (assoc :strict-builtin-errors true))]
     (doseq [entry-point entry-points]
       (let [want-result (get want-results entry-point)


### PR DESCRIPTION
This solves the opa.runtime test which failed, since
the OPA tests have mocked this to return an empty map..
but more importantly, it will allow us and others to
easily provide their set of builtins, or even swap out
the ones that we provide.

Touching some code that isn't my domain here, so if this
feels hacky, let me know.

Signed-off-by: Anders Eknert <anders@eknert.com>