### PR TITLE
Making contains-check in `DotStmt` before value extraction

### DIFF
--- a/src/main/clojure/jarl/builtins/objects.clj
+++ b/src/main/clojure/jarl/builtins/objects.clj
@@ -8,6 +8,7 @@
   "Implementation of object.get built-in"
   {:builtin "object.get" :args-types ["object", "any", "any"]}
   [{[object key default] :args}]
+  (check-args (meta #'builtin-object-get) object key)
   (if (vector? key)
     (get-in object key default)
     (get object key default)))

--- a/src/main/clojure/jarl/exceptions.clj
+++ b/src/main/clojure/jarl/exceptions.clj
@@ -1,10 +1,11 @@
 (ns jarl.exceptions
-  (:import (se.fylling.jarl BuiltinException
+  (:import (se.fylling.jarl AssignmentConflictException
+                            BuiltinException
                             ConflictException
+                            JarlException
                             MultipleOutputsConflictException
                             TypeException
-                            UndefinedException
-                            JarlException)))
+                            UndefinedException)))
 
 (defn builtin-ex [message & args]
   (BuiltinException. (apply format message args)))
@@ -14,6 +15,9 @@
 
 (defn conflict-ex [message & args]
   (ConflictException. (apply format message args)))
+
+(defn assignment-conflict-ex [message & args]
+  (AssignmentConflictException. (apply format message args)))
 
 (defn multiple-outputs-conflict-ex [cause message & args]
   (MultipleOutputsConflictException. (apply format message args) cause))

--- a/src/main/java/se/fylling/jarl/AssignmentConflictException.java
+++ b/src/main/java/se/fylling/jarl/AssignmentConflictException.java
@@ -1,0 +1,11 @@
+package se.fylling.jarl;
+
+public class AssignmentConflictException extends ConflictException {
+    public AssignmentConflictException(String message) {
+        super(message);
+    }
+
+    public AssignmentConflictException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/se/fylling/jarl/MultipleOutputsConflictException.java
+++ b/src/main/java/se/fylling/jarl/MultipleOutputsConflictException.java
@@ -1,6 +1,6 @@
 package se.fylling.jarl;
 
-public class MultipleOutputsConflictException extends ConflictException {
+public class MultipleOutputsConflictException extends AssignmentConflictException {
     public MultipleOutputsConflictException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/src/test/clojure/jarl/compliance_test.clj
+++ b/src/test/clojure/jarl/compliance_test.clj
@@ -101,15 +101,17 @@
 (defn- generate-tests
   "Generate tests and intern them in the namespace"
   []
-  (doseq [test-case (read-test-cases)]
-    (let [{:strs [note plan]} test-case
-          test-name (str/replace note #"[/\s]" "_")]
-      (if (ir-supported? plan)
-        (add-test test-name
-                  'jarl.compliance-test
-                  #(do-test test-case)
-                  {:compliance true})
-        (println "Ignoring" test-name)))))
+  (let [test-to-run (get (System/getenv) "TEST")]
+    (doseq [test-case (read-test-cases)]
+      (let [{:strs [note plan]} test-case
+            test-name (str/replace note #"[/\s]" "_")]
+        (if (and (or (nil? test-to-run) (= note test-to-run))
+                 (ir-supported? plan))
+          (add-test test-name
+                    'jarl.compliance-test
+                    #(do-test test-case)
+                    {:compliance true})
+          (println "Ignoring" test-name))))))
 
 ; Trick `lein test` into consider this namespace before the tests have been generated
 (deftest ^:compliance phony

--- a/src/test/clojure/jarl/eval_test.clj
+++ b/src/test/clojure/jarl/eval_test.clj
@@ -3,6 +3,7 @@
             [jarl.eval :refer [eval-ArrayAppendStmt
                                eval-AssignVarStmt
                                eval-AssignVarOnceStmt
+                               eval-DotStmt
                                eval-IsObjectStmt eval-LenStmt
                                eval-MakeNumberIntStmt
                                eval-MakeObjectStmt
@@ -139,6 +140,72 @@
           state {:local {}}
           result-state (eval-AssignVarOnceStmt source-index target state)]
       (is (= result-state state)))))
+
+(deftest eval-DotStmt-test
+  (testing "get in object"
+    (let [target-index 42
+          key 13
+          key-index 3
+          key-pos (make-local-value-key key-index)
+          value 37
+          source-value {key value}
+          source-index 2
+          source-pos (make-local-value-key source-index)
+          state {}
+          state (set-local state key-index key)
+          state (set-local state source-index source-value)
+          result-state (eval-DotStmt source-pos key-pos target-index state)
+          result (get-local result-state target-index)]
+      (is (not (contains? result-state :break-index)))
+      (is (= result value))))
+  (testing "get in empty object"
+    (let [target-index 42
+          key 13
+          key-index 3
+          key-pos (make-local-value-key key-index)
+          source-value {}
+          source-index 2
+          source-pos (make-local-value-key source-index)
+          state {}
+          state (set-local state key-index key)
+          state (set-local state source-index source-value)
+          result-state (eval-DotStmt source-pos key-pos target-index state)]
+      (is (contains? result-state :break-index))))
+  (testing "get in array"
+    (let [target-index 42
+          key 13
+          key-index 3
+          key-pos (make-local-value-key key-index)
+          source-value [1 2 3]
+          source-index 2
+          source-pos (make-local-value-key source-index)
+          state {}
+          state (set-local state key-index key)
+          state (set-local state source-index source-value)
+          result-state (eval-DotStmt source-pos key-pos target-index state)]
+      (is (contains? result-state :break-index))))
+  (testing "key not present"
+    (let [target-index 42
+          key-index 3
+          key-pos (make-local-value-key key-index)
+          source-value [1 2 3]
+          source-index 2
+          source-pos (make-local-value-key source-index)
+          state {}
+          state (set-local state source-index source-value)
+          result-state (eval-DotStmt source-pos key-pos target-index state)]
+      (is (contains? result-state :break-index))))
+  (testing "source not present"
+    (let [target-index 42
+          key 13
+          key-index 3
+          key-pos (make-local-value-key key-index)
+          source-index 2
+          source-pos (make-local-value-key source-index)
+          state {}
+          state (set-local state key-index key)
+          result-state (eval-DotStmt source-pos key-pos target-index state)]
+      (is (contains? result-state :break-index)))))
 
 (deftest eval-MakeObjectStmt-test
   (testing "make an empty object"


### PR DESCRIPTION
Also fixing:
* `object.get` built-in arg check
* throwing `ConflictException` in `ObjectInsertOnceStmt` on inserts changing existing value

Signed-off-by: Johan Fylling <johan.dev@fylling.se>