### PR TITLE
More time builtins

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,9 +184,9 @@ https://github.com/google/re2j
 - [ ] `time.date`
 - [ ] `time.diff`
 - [x] `time.now_ns`
-- [ ] `time.parse_duration_ns`
-- [ ] `time.parse_ns`
-- [ ] `time.parse_rfc3339_ns`
+- [x] `time.parse_duration_ns`
+- [x] `time.parse_ns`
+- [x] `time.parse_rfc3339_ns`
 - [x] `time.weekday`
 
 ### Cryptography

--- a/src/main/clojure/jarl/builtins/regex.clj
+++ b/src/main/clojure/jarl/builtins/regex.clj
@@ -20,7 +20,8 @@
 (defn builtin-re-match [{[pattern ^String value] :args}]
   (try
     (builtin-regex-match {:args [pattern value]})
-    (catch BuiltinException e (str/replace (.getMessage e) #"regex\.match" "re_match"))))
+    (catch BuiltinException e
+      (throw (errors/builtin-ex (str/replace (.getMessage e) #"regex\.match" "re_match"))))))
 
 (defn builtin-regex-is-valid
   "Implementation of regex.is_valid built-in"

--- a/src/main/clojure/jarl/builtins/registry.clj
+++ b/src/main/clojure/jarl/builtins/registry.clj
@@ -126,6 +126,8 @@
 
    "time.now_ns"              time/builtin-time-now-ns
    "time.weekday"             time/builtin-time-weekday
+   "time.parse_duration_ns"   time/builtin-time-parse-duration-ns
+   "time.parse_ns"            time/builtin-time-parse-ns
    "time.parse_rfc3339_ns"    time/builtin-time-parse-rfc3339-ns
 
    "crypto.hmac.md5"          crypto/builtin-crypto-hmac-md5

--- a/src/main/clojure/jarl/builtins/strings.clj
+++ b/src/main/clojure/jarl/builtins/strings.clj
@@ -81,7 +81,10 @@
   {:builtin "format_int" :args-types ["number" "number"]}
   [{[number base] :args}]
   (check-args (meta #'builtin-format-int) number base)
-  (Integer/toString number base))
+  (if-not (contains? #{2 8 10 16} base)
+    (throw (errors/type-ex "format_int: operand 2 must be one of {2, 8, 10, 16}"))
+    (Integer/toString number base)))
+
 
 (defn builtin-indexof
   "Implementation of indexof built-in"

--- a/src/main/clojure/jarl/builtins/time.clj
+++ b/src/main/clojure/jarl/builtins/time.clj
@@ -1,23 +1,102 @@
 (ns jarl.builtins.time
   (:require [jarl.builtins.utils :refer [check-args]]
             [jarl.exceptions :as errors]
-            [jarl.utils :refer [instant-to-ns]])
-  (:import (java.time Instant ZoneId LocalDateTime ZoneOffset ZonedDateTime)
+            [jarl.utils :refer [instant-to-ns ns-to-instant]]
+            [clojure.string :as str])
+  (:import (java.time ZoneId LocalDateTime ZoneOffset ZonedDateTime Duration)
            (java.time.format TextStyle DateTimeFormatter)
-           (java.util Locale)))
+           (java.util Locale)
+           (java.time.temporal ChronoUnit)))
 
-(defn parse-iso-datetime [s]
-  (-> s
-      (LocalDateTime/parse DateTimeFormatter/ISO_LOCAL_DATE_TIME)
-      (.toInstant ZoneOffset/UTC)))
+; Courtesy of https://github.com/newm4n/go-dfe
+(def go->java-map
+  {; Go          Java
+   "January"   "MMMM"
+   "Jan"       "MMM"
+   "1"         "M"
+   "01"        "MM"
+   "Monday"    "EEEE"
+   "Mon"       "EEE"
+   "2"         "d"
+   "_2"        "_d"
+   "02"        "dd"
+   "15"        "HH"
+   "3"         "K"
+   "03"        "KK"
+   "4"         "m"
+   "04"        "mm"
+   "5"         "s"
+   "05"        "ss"
+   "2006"      "yyyy"
+   "06"        "yy"
+   "PM"        "aa"
+   "pm"        "aa"
+   "MST"       "Z"
+   "Z0700"     "'Z'XX"
+   "Z070000"   "'Z'XX"
+   "Z07"       "'Z'X"
+   "Z07:00"    "'Z'XXX"
+   "Z07:00:00" "'Z'XXX"
+   "-0700"     "XX"
+   "-070000"   "'Z'XX"
+   "-07"       "X"
+   "-07:00"    "XXX"
+   "-07:00:00" "XXX"
+   "999999999" "SSS"})
 
-(defn parse-iso-zoned-datetime [s]
-  (-> s
-      (ZonedDateTime/parse DateTimeFormatter/ISO_ZONED_DATE_TIME)
-      (.toInstant)))
+(defn- key-length-sorter
+  "Sort by key length (with the longest first) but treat equal key length as different in order to not discard them"
+  [x y]
+  (let [cmp (compare (count y) (count x))]
+    (if (zero? cmp) -1 cmp)))
 
-(defn- instant-from-ns ^Instant [ns]
-  (Instant/ofEpochSecond 0 ns))
+(def go->java-sorted-map (into (sorted-map-by key-length-sorter) go->java-map))
+
+(defn- go->java-formatter ^String [format]
+  (reduce (fn [acc [go java]] (str/replace acc go java)) format go->java-sorted-map))
+
+(defn parse-iso-datetime
+  ([s]
+   (parse-iso-datetime s DateTimeFormatter/ISO_LOCAL_DATE_TIME))
+  ([s f]
+   (-> s (LocalDateTime/parse f) (.toInstant ZoneOffset/UTC))))
+
+(defn parse-iso-zoned-datetime
+  ([s]
+   (parse-iso-zoned-datetime s DateTimeFormatter/ISO_ZONED_DATE_TIME))
+  ([s f]
+   (-> s (ZonedDateTime/parse f) (.toInstant))))
+
+(defn parse-formatted-datetime [s f]
+  (if (= f "01/02 03:04:05PM '06 -0700")
+    ; special case for what Go docs refer to as "reference time": 01/02 03:04:05PM '06 -0700
+    ; https://pkg.go.dev/time#pkg-constants
+    (parse-iso-zoned-datetime (str/replace s #"'" "") (DateTimeFormatter/ofPattern "MM/dd hh:mm:ssa yy XX"))
+    ; everything else
+    (let [pattern (go->java-formatter f)]
+      (if (re-find #"[ZXx]" pattern) ; time zone in pattern
+        (errors/try-or
+          (parse-iso-zoned-datetime s (DateTimeFormatter/ofPattern pattern))
+          (parse-iso-zoned-datetime s))
+        (parse-iso-datetime s (DateTimeFormatter/ofPattern pattern))))))
+
+(def unit->temporal
+  {"h"  ChronoUnit/HOURS
+   "m"  ChronoUnit/MINUTES
+   "s"  ChronoUnit/SECONDS
+   "ms" ChronoUnit/MILLIS
+   "us" ChronoUnit/MICROS
+   "µs" ChronoUnit/MICROS
+   "ns" ChronoUnit/NANOS})
+
+(defn d [^long time ^ChronoUnit unit]
+  (Duration/of time unit))
+
+(defn d+
+  ([^Duration d1 ^Duration d2]
+    (.plus d1 d2))
+  ([^Duration d1 ^Duration d2 & more]
+   (reduce d+ (d+ d1 d2) more)))
 
 (defn builtin-time-now-ns
   "Implementation of time.now_ns built-in"
@@ -31,10 +110,36 @@
   [{[x] :args}]
   (check-args (meta #'builtin-time-weekday) x)
   (let [v (if (vector? x) x [x])]
-      (-> (instant-from-ns (errors/try-or-throw #(long (first v)) (errors/builtin-ex "time.weekday: timestamp too big")))
+      (-> (ns-to-instant (errors/try-or-throw #(long (first v)) (errors/builtin-ex "time.weekday: timestamp too big")))
           (.atZone (ZoneId/of (or (second v) "UTC")))
           (.getDayOfWeek)
           (.getDisplayName TextStyle/FULL Locale/ENGLISH))))
+
+(defn unknown-duration-ex [unit time]
+  (errors/builtin-ex "time.parse_duration_ns: time: unknown unit \"%s\" in duration \"%s\""
+                     unit (str time unit)))
+
+(defn to-duration [[_ time unit]]
+  (d (Long/parseLong time) (errors/get-or-throw unit->temporal unit (unknown-duration-ex unit time))))
+
+(defn builtin-time-parse-duration-ns
+  "Implementation of time.parse_duration_ns built-in"
+  {:builtin "time.parse_duration_ns" :args-types ["string"]}
+  [{[s] :args}]
+  (check-args (meta #'builtin-time-parse-duration-ns) s)
+  (if-let [time-unit-pairs (re-seq #"(\d+)(\p{L}+)" s)] ; returns a seq of [full match, time, unit]
+    (.toNanos ^Duration (reduce d+ (map to-duration time-unit-pairs)))
+    (if (errors/throws? #(Long/parseLong s))
+      (throw (errors/builtin-ex "time.parse_duration_ns: time: invalid duration \"%s\"" s))
+      (throw (errors/builtin-ex "time.parse_duration_ns: time: missing unit in duration \"%s\"" s)))))
+
+(defn builtin-time-parse-ns
+  "Implementation of time.parse_ns built-in"
+  {:builtin "time.parse_ns" :args-types ["string" "string"]}
+  [{[layout value] :args}]
+  (check-args (meta #'builtin-time-parse-ns) value layout)
+  (let [nanos (instant-to-ns (parse-formatted-datetime value layout))]
+    (errors/try-or-throw #(long nanos) (errors/builtin-ex "time.parse_ns: time outside of valid range"))))
 
 (defn builtin-time-parse-rfc3339-ns
   "Implementation of time.parse_rfc3339_ns built-in"

--- a/src/main/clojure/jarl/exceptions.clj
+++ b/src/main/clojure/jarl/exceptions.clj
@@ -49,6 +49,11 @@
     (catch Throwable _
       (throw ex))))
 
+(defn get-or-throw [m key ex]
+  (if-not (contains? m key)
+    (throw ex)
+    (get m key)))
+
 (defn throws?
   "Return true if invoking func throws exception"
   [func]

--- a/src/main/clojure/jarl/utils.clj
+++ b/src/main/clojure/jarl/utils.clj
@@ -37,6 +37,9 @@
 (defn instant-to-ns [^Instant instant]
   (+' (*' (.getEpochSecond instant) 1000000000) (.getNano instant)))
 
+(defn ns-to-instant ^Instant [ns]
+  (Instant/ofEpochSecond 0 ns))
+
 (defn time-now-ns
   "Current time nanos — not as precise as its OPA/Go equivalent function, but not in any way that matters"
   []

--- a/src/test/clojure/jarl/builtins/regex_test.clj
+++ b/src/test/clojure/jarl/builtins/regex_test.clj
@@ -1,9 +1,15 @@
 (ns jarl.builtins.regex-test
   (:require [clojure.test :refer [deftest]]
-            [test.utils :refer [testing-builtin]]))
+            [test.utils :refer [testing-builtin]])
+  (:import (se.fylling.jarl BuiltinException)))
 
 (deftest builtin-regex-match-test
   (testing-builtin "regex.match"
+    ["[\\d]+" "123"] true
+    ["][" "foo[\"bar\"]"] [BuiltinException "error parsing regexp: missing closing ]"]))
+
+(deftest builtin-re-match-test
+  (testing-builtin "re_match"
     ["[\\d]+" "123"] true))
 
 (deftest builtin-regex-is-valid-test

--- a/src/test/clojure/jarl/builtins/time_test.clj
+++ b/src/test/clojure/jarl/builtins/time_test.clj
@@ -1,9 +1,10 @@
 (ns jarl.builtins.time-test
   (:require [clojure.test :refer [deftest]]
-            [jarl.utils :refer [instant-to-ns]]
+            [jarl.utils :refer [instant-to-ns ns-to-instant]]
             [test.utils :refer [testing-builtin]]
-            [jarl.builtins.time :refer [parse-iso-datetime]])
-  (:import (se.fylling.jarl BuiltinException)))
+            [jarl.builtins.time :refer [parse-iso-datetime parse-iso-zoned-datetime]])
+  (:import (se.fylling.jarl BuiltinException)
+           (java.time.temporal ChronoUnit)))
 
 (deftest builtin-time-now-ns-test
   (testing-builtin "time.now_ns"
@@ -20,6 +21,37 @@
       ; exceptions
       [9655283296943749000]      [BuiltinException "timestamp too big"])))
 
+(deftest builtin-time-parse-duration-ns-test
+  (testing-builtin "time.parse_duration_ns"
+    ["1ns"]                     1
+    ["1ns2ms"]                  2000001
+    ["1h"]                      3600000000000
+    ["33h11m59s7ms99us12345ns"] 119519007111345
+    ; exceptions
+    ["h"]                       [BuiltinException "time: invalid duration \"h\""]
+    ["33"]                      [BuiltinException "time: missing unit in duration \"33\""]
+    ["33ks"]                    [BuiltinException "time: unknown unit \"ks\" in duration \"33ks\""]))
+
+(deftest builtin-time-parse-ns-test
+  (let [ref-time (instant-to-ns (parse-iso-zoned-datetime "2022-01-01T12:12:12.00-00:00")) ; 1641039132000000000
+        ref-time-tz-offset (instant-to-ns (-> (ns-to-instant ref-time) (.plus 8 ChronoUnit/HOURS)))]
+    (testing-builtin "time.parse_ns"
+      ["Mon Jan 02 15:04:05 2006" "Sat Jan 01 12:12:12 2022"]             ref-time
+      ; ANSIC
+      ["Mon Jan _2 15:04:05 2006" "Sat Jan _1 12:12:12 2022"]             ref-time
+      ; UnixDate
+      ["Mon Jan _2 15:04:05 MST 2006" "Sat Jan _1 12:12:12 -0000 2022"]   ref-time
+      ["Mon Jan _2 15:04:05 MST 2006" "Sat Jan _1 12:12:12 -0800 2022"]   ref-time-tz-offset
+      ; RubyDate
+      ["Mon Jan 02 15:04:05 -0700 2006" "Sat Jan 01 12:12:12 -0800 2022"] ref-time-tz-offset
+      ; Reference time format
+      ["01/02 03:04:05PM '06 -0700" "01/01 12:12:12PM '22 -0000"]         ref-time
+      ["01/02 03:04:05PM '06 -0700" "06/02 07:00:00PM '17 -0700"]         1496455200000000000
+      ; exceptions
+      ["2006-01-02T15:04:05Z07:00" "2262-04-11T23:47:16.854775808-00:00"] [BuiltinException "time outside of valid range"])))
+
 (deftest builtin-time-parse-rfc3339-ns-test
   (testing-builtin "time.parse_rfc3339_ns"
-    ["2022-01-01T00:00:00.145224191-00:00"] 1640995200145224191))
+    ["2022-01-01T12:12:12.00-00:00"]        1641039132000000000
+    ["2022-01-01T00:00:00.145224191-00:00"] 1640995200145224191
+    ["2262-04-11T23:47:16.854775808-00:00"] [BuiltinException "time outside of valid range"]))

--- a/src/test/clojure/test/utils.clj
+++ b/src/test/clojure/test/utils.clj
@@ -52,9 +52,9 @@
                        ; else - not vector
                        (if (map? args)
                          ; allow providing the entire request map if needed
-                         `(is (= (~func ~args) ~expect))
+                         `(is (= (~func ~args) ~expect) (str "For input: " ~args))
                          ; but since most tests only care for the args, a vector of those is more convenient
-                         `(is (= (~func {:args ~args}) ~expect)))))
+                         `(is (= (~func {:args ~args}) ~expect) (str "For input: " ~args)))))
                    pairs)]
     `(clojure.test/testing ~func-name
        ~@stmts)))


### PR DESCRIPTION
* Add time.parse_ns
* Add time.parse_duration_ns
* Fix two compliance violations

Signed-off-by: Anders Eknert <anders@eknert.com>