### PR TITLE
Allowing entry-points in compliance-tests to not generate errors

### DIFF
--- a/src/test/clojure/jarl/builtins/aggregates_test.clj
+++ b/src/test/clojure/jarl/builtins/aggregates_test.clj
@@ -5,13 +5,13 @@
 
 (deftest builtin-count-test
   (testing-builtin "count"
-    [[]]              0
-    [[1]]             1
-    [[1 "a"]]         2
-    ["abc"]           3
-    [(range 11)]      11
-    ["🍧🍨🧁🍰🍮"]   5
-    ["🇩🇪"]            2))
+    [[]]               0
+    [[1]]              1
+    [[1 "a"]]          2
+    ["abc"]            3
+    [(vec (range 11))] 11
+    ["🍧🍨🧁🍰🍮"]      5
+    ["🇩🇪"]             2))
 
 (deftest builtin-sum-test
   (testing-builtin "sum"

--- a/src/test/clojure/jarl/compliance_test.clj
+++ b/src/test/clojure/jarl/compliance_test.clj
@@ -84,16 +84,16 @@
     (if (and (nil? want-error-code) (nil? want-error))
       (let [result (eval-entry-points-for-results info entry-points data input)]
         (is (= result want-result)))
-      (let [errors (eval-entry-points-for-errors info entry-points data input)]
-        ; There might be other errors generated than what is expected by the test case definition, but the test case
-        ; doesn't know we're executing multiple entry-points, so we can't count unexpected JarlExceptions as violations
-        (is (>= (count (filter
-                         (fn [^JarlException error]
+      (let [errors (eval-entry-points-for-errors info entry-points data input)
+            error-filter (fn [^JarlException error]
                            (and
                              (= (.getType error) want-error-code)
                              (.contains (.getMessage error) want-error)))
-                         errors))
-                1) (str "Expected error code:" want-error-code "; message: " want-error ", got" errors))))))
+            jarl-errors (filter error-filter errors)]
+        ; There might be other errors generated than what is expected by the test case definition, but the test case
+        ; doesn't know we're executing multiple entry-points, so we can't count unexpected JarlExceptions as violations
+        (is (not-empty jarl-errors)
+            (str "Expected error code:" want-error-code "; message: " want-error ", got" errors))))))
 
 ;
 ; Test generator


### PR DESCRIPTION
... as even though when an error is expected, not all entry-points will generate that error.

Signed-off-by: Johan Fylling <johan.dev@fylling.se>