### PR TITLE
Add clj-async-profiler lab code

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -30,14 +30,17 @@
                    :performance      :performance}
   :profiles {:dev  {:dependencies   [[junit/junit "4.13.2"]
                                      [com.bhauman/rebel-readline "0.1.4"]
+                                     [com.clojure-goes-fast/clj-async-profiler "1.0.0"]
                                      [cider/piggieback "0.5.3"]
                                      [criterium "0.4.6"]
                                      [zprint "1.2.3"]]
                     :resource-paths ["src/test/resources"]
+                    :jvm-opts       ["-Djdk.attach.allowAttachSelf"]
                     :repl-options   {:nrepl-middleware [cider.piggieback/wrap-cljs-repl]}
                     :plugins        [[lein-cljsbuild "1.1.8"]
                                      [lein-ancient "1.0.0-RC3"]]
-                    :eastwood {:exclude-linters [:constant-test]}}
+                    :eastwood {:exclude-linters [:constant-test]
+                               :exclude-namespaces [test.profile]}}
              :test {:injections [(require 'test.config)
                                  (taoensso.timbre/set-level! :warn)]}
              :clj-kondo {:plugins [[com.github.clj-kondo/lein-clj-kondo "0.2.1"]]}

--- a/src/test/clojure/test/profile.clj
+++ b/src/test/clojure/test/profile.clj
@@ -1,0 +1,19 @@
+(ns test.profile
+  "Profiler generating flame graphs. See https://github.com/clojure-goes-fast/clj-async-profiler for details"
+  (:require [clojure.test :refer [run-test-var run-tests]]
+            [taoensso.timbre :as log]
+            [clj-async-profiler.core :as prof]
+            [test.compliance.generated.tests]))
+
+; NOTE: needs to be run with -Djdk.attach.allowAttachSelf
+(defn -main []
+  (log/set-level! :info)
+
+  (prof/profile
+    (dotimes [_ 100]
+      (run-tests 'test.compliance.generated.tests)
+      (comment "or call any function. to run a single test, yoy may use:"
+        (run-test-var (resolve 'test.compliance.generated.tests/aggregates-member+some+key+ref)))))
+
+  ; Serve flame graphs from local server
+  (prof/serve-files 8080))


### PR DESCRIPTION
Checking in some lab code from playing around with the
(seemingly excellent) clj-async-profiler. A few observations
made but nothing to act on yet. Good to have here for later
excursions though!

<img width="1360" alt="Screenshot 2022-07-26 at 21 44 25" src="https://user-images.githubusercontent.com/510711/181101548-a55b41c8-c1e4-408d-83c5-036e6f9b0988.png">

Signed-off-by: Anders Eknert <anders@eknert.com>