### PR TITLE
Workaround for weird JVM datetime parsing AM vs. am

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -39,7 +39,8 @@
                     :jvm-opts       ["-Djdk.attach.allowAttachSelf"]
                     :repl-options   {:nrepl-middleware [cider.piggieback/wrap-cljs-repl]}
                     :plugins        [[lein-cljsbuild "1.1.8"]
-                                     [lein-ancient "1.0.0-RC3"]]
+                                     [lein-ancient "1.0.0-RC3"]
+                                     [lein-cloverage "1.2.4"]]
                     :eastwood {:exclude-linters [:constant-test]
                                :exclude-namespaces [test.profile]}}
              :test {:injections [(require 'test.config)

--- a/src/test/clojure/jarl/builtins/time_test.clj
+++ b/src/test/clojure/jarl/builtins/time_test.clj
@@ -70,8 +70,7 @@
       ["2006-01-02" "2022-01-01"] 1640995200000000000
       ; exceptions
       ["2006-01-02T15:04:05Z07:00" "2262-04-11T23:47:16.854775808-00:00"] [:jarl.exceptions/builtin-exception
-                                                                           "time outside of valid range"]
-      )))
+                                                                           "time outside of valid range"])))
 
 (deftest builtin-time-parse-rfc3339-ns-test
   (testing-builtin "time.parse_rfc3339_ns"


### PR DESCRIPTION
Fixes #58

Signed-off-by: Anders Eknert <anders@eknert.com>